### PR TITLE
feat(restaurant): 식당메뉴 등록/수정 후 식당등록 페이지 복귀 시 이미지 사라짐 오류 수정

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,6 +1,8 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import HomeView from '../views/HomeView.vue';
 
+import { useRestaurantStore } from '@/stores/restaurant';
+
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
@@ -258,4 +260,26 @@ const router = createRouter({
   ],
 });
 
+router.beforeEach((to, from) => {
+  // Pinia 스토어는 Vue 앱이 실행된 후에 사용 가능하므로, 가드 내에서 직접 호출합니다.
+  const store = useRestaurantStore();
+
+  // 식당 정보 등록/수정 워크플로우에 해당하는 라우트 이름 목록
+  const workflowRoutes = [
+    'business-restaurant-info-add',
+    'business-restaurant-info-edit',
+    'business-restaurant-menu-add',
+    'business-restaurant-menu-edit',
+  ];
+
+  const isFromWorkflow = workflowRoutes.includes(from.name);
+  const isToWorkflow = workflowRoutes.includes(to.name);
+
+  // 워크플로우를 벗어나는 경우에만 store를 초기화합니다.
+  if (isFromWorkflow && !isToWorkflow) {
+    store.clearRestaurant();
+  }
+});
+
 export default router;
+

--- a/frontend/src/stores/restaurant.js
+++ b/frontend/src/stores/restaurant.js
@@ -57,11 +57,22 @@ export const useRestaurantStore = defineStore('restaurant', () => {
     return Date.now();
   }
 
+  function setDraftImageUrl(url) {
+    if (!restaurantInfo.value) {
+      restaurantInfo.value = { images: [] };
+    }
+    if (!restaurantInfo.value.images || restaurantInfo.value.images.length === 0) {
+      restaurantInfo.value.images = [{ imageUrl: null }];
+    }
+    restaurantInfo.value.images[0].imageUrl = url;
+  }
+
   return { 
     restaurantInfo,
     menus, 
     loadRestaurant,
     clearRestaurant,
+    setDraftImageUrl,
     addMenu, 
     updateMenu, 
     deleteMenu,


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 식당메뉴 등록/수정 후 식당정보 등록 페이지로 복귀할 때의 이미지 사라짐 오류도 수정
- 식당정보 등록 페이지에서 식당메뉴 등록/수정 페이지 이외의 다른 페이지로 이동했다가 복귀할 때는 작성중이던 내용 초기화
(직전 PR(#77)에서 push하지 못하고 누락되었던 커밋 1개를 추가합니다.)

## 📁 변경된 파일

- frontend/src/router/index.js
- frontend/src/stores/restaurant.js
- frontend/src/views/business/restaurant-info/edit/RestaurantInfoEditPage.vue

## 🔗 관련 Issue(선택)

- [식당메뉴 등록 후 식당등록 페이지 복귀 시 이미지 사라짐 오류 수정 #78](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/78)
- [사업자 전용 식당관리 기능 백엔드 구현 전 사전 준비 작업 #50](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/50)

## ✔️ 체크리스트(선택)

- 식당정보 등록 페이지에서 이미지 등록 -> 식당메뉴 등록/수정 -> 식당정보 등록 페이지 복귀: 작성 중인 기존 데이터 유지 (확인 완료)
- 식당정보 등록 페이지에서 이미지 등록 -> 식당정보 조회 페이지 이동 -> 식당정보 등록 페이지 복귀: 작성하던 내용 초기화 (확인 완료)
