### PR TITLE
design(restaurant): 식당메뉴 리스트 컴포넌트 분리 및 사업자 전용 식당메뉴 조회 페이지 추가

### DIFF
--- a/frontend/src/components/ui/BusinessSideBar.vue
+++ b/frontend/src/components/ui/BusinessSideBar.vue
@@ -1,5 +1,7 @@
 <script setup>
+import { computed } from 'vue';
 import { RouterLink } from 'vue-router';
+import { useRestaurantStore } from '@/stores/restaurant';
 
 // 'activeMenu' 라는 이름의 prop을 정의합니다.
 defineProps({
@@ -8,6 +10,9 @@ defineProps({
     required: true,
   },
 });
+
+const restaurantStore = useRestaurantStore();
+const restaurantId = computed(() => restaurantStore.restaurantInfo?.restaurantId || 1); // 스토어에 ID가 없을 경우 임시로 1을 사용
 </script>
 
 <template>
@@ -54,7 +59,7 @@ defineProps({
         </li>
         <li>
           <RouterLink
-            to="/business/restaurant-info"
+            :to="`/business/restaurant-info/${restaurantId}`"
             :class="[
               'block px-4 py-3 rounded-lg transition-colors',
               activeMenu === 'restaurant-info'

--- a/frontend/src/components/ui/RestaurantMenuList.vue
+++ b/frontend/src/components/ui/RestaurantMenuList.vue
@@ -1,0 +1,78 @@
+<template>
+  <template v-if="menuCategories.length">
+    <section
+      v-for="(category, idx) in menuCategories"
+      :key="category.id || idx"
+      class="mb-6"
+    >
+      <div class="flex items-center justify-between mb-3 px-1">
+        <h3 class="text-base font-semibold text-[#1e3a5f]">
+          {{ category.name }}
+        </h3>
+        <p class="text-xs text-[#adb5bd]">총 {{ category.items.length }}개</p>
+      </div>
+
+      <div class="space-y-3">
+        <Card
+          v-for="(item, itemIdx) in category.items"
+          :key="item.id || itemIdx"
+          class="p-3 border-[#e9ecef] rounded-xl bg-white shadow-card hover:shadow-md transition-shadow"
+        >
+          <div class="flex items-center gap-3">
+            <img
+              :src="item.image || fallbackImage"
+              :alt="item.name"
+              class="w-20 h-20 rounded-lg object-cover flex-shrink-0"
+            />
+            <div class="flex-1 min-w-0">
+              <div class="flex items-start justify-between gap-4">
+                <p class="menu-title text-[#1e3a5f]">
+                  {{ item.name }}
+                </p>
+                <p class="font-semibold text-[#ff6b4a] whitespace-nowrap">
+                  {{ item.price }}
+                </p>
+              </div>
+              <p
+                v-if="item.description"
+                class="text-xs text-[#6c757d] leading-relaxed mt-1"
+              >
+                {{ item.description }}
+              </p>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </section>
+  </template>
+
+  <div
+    v-else
+    class="py-20 text-center text-sm text-[#6c757d] bg-white rounded-2xl"
+  >
+    메뉴 정보가 곧 업데이트될 예정입니다.
+  </div>
+</template>
+
+<script setup>
+import Card from '@/components/ui/Card.vue';
+
+defineProps({
+  menuCategories: {
+    type: Array,
+    required: true,
+  },
+});
+
+const fallbackImage = '/placeholder.svg';
+</script>
+
+<style scoped>
+.menu-title {
+  font-weight: 600;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -53,10 +53,18 @@ const router = createRouter({
       props: true,
     },
     {
-      path: '/business/restaurant-info',
+      path: '/business/restaurant-info/:id',
       name: 'business-restaurant-info',
       component: () =>
         import('../views/business/restaurant-info/RestaurantInfoPage.vue'),
+      props: true,
+    },
+    {
+      path: '/business/restaurant-info/:id/menus',
+      name: 'business-restaurant-menus',
+      component: () =>
+        import('../views/business/restaurant-info/menu/MenusInfoPage.vue'),
+      props: true,
     },
     {
       path: '/business/staff',

--- a/frontend/src/views/business/restaurant-info/RestaurantInfoPage.vue
+++ b/frontend/src/views/business/restaurant-info/RestaurantInfoPage.vue
@@ -1,11 +1,16 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue';
-import { RouterLink, useRoute } from 'vue-router';
+import { RouterLink } from 'vue-router'; // Removed useRoute
 import BusinessSidebar from '@/components/ui/BusinessSideBar.vue';
 import BusinessHeader from '@/components/ui/BusinessHeader.vue';
 
-// 1. 라우터
-const route = useRoute();
+// Define props to receive the restaurant ID from the route
+const props = defineProps({
+  id: {
+    type: String,
+    required: true,
+  },
+});
 
 // 2. 상태
 const restaurant = ref(null); // API로부터 받은 식당 정보를 저장할 ref
@@ -41,9 +46,11 @@ const mainImageUrl = computed(() => {
 // 5. 라이프사이클 훅
 // 추후 API로부터 데이터를 받아오는 로직을 처리할 함수
 onMounted(() => {
-  // API: GET /api/my-restaurant
+  // API: GET /api/my-restaurant/:id
+  // Here, you would typically make an API call to fetch restaurant data using props.id
+  // For now, we'll use a mock data, but simulate using props.id
   const mockRestaurantDataFromApi = {
-    restaurantId: 1,
+    restaurantId: props.id, // Use the prop ID here
     name: '런치고 한정식',
     phone: '02-1234-5678',
     roadAddress: '서울특별시 강남구 테헤란로 123',
@@ -294,15 +301,19 @@ onMounted(() => {
           </div>
 
           <!-- View All Menus Button -->
-          <button
-            class="w-full gradient-primary text-white py-4 rounded-xl text-lg font-semibold hover:opacity-90 transition-opacity"
+          <RouterLink
+            :to="{
+              name: 'business-restaurant-menus',
+              params: { id: props.id },
+            }"
+            class="block w-full text-center gradient-primary text-white py-4 rounded-xl text-lg font-semibold hover:opacity-90 transition-opacity"
           >
             식당메뉴 전체보기
-          </button>
+          </RouterLink>
 
           <!-- Edit Button -->
           <div class="flex justify-end">
-            <RouterLink :to="`/business/restaurant-info/edit/${restaurant.restaurantId}`">
+            <RouterLink :to="`/business/restaurant-info/edit/${props.id}`">
               <button
                 class="px-8 py-3 border-2 border-[#FF6B4A] text-[#FF6B4A] rounded-xl font-semibold hover:bg-[#fff5f2] transition-colors"
               >

--- a/frontend/src/views/business/restaurant-info/RestaurantInfoPage.vue
+++ b/frontend/src/views/business/restaurant-info/RestaurantInfoPage.vue
@@ -258,7 +258,7 @@ onMounted(() => {
                 <label class="block text-sm font-semibold text-[#1e3a5f] mb-2">
                   정기휴무일
                 </label>
-                <div class="flex gap-3">
+                <div class="flex flex-wrap gap-3">
                   <button
                     v-for="day in ['월', '화', '수', '목', '금', '토', '일']"
                     :key="day"

--- a/frontend/src/views/business/restaurant-info/menu/MenusInfoPage.vue
+++ b/frontend/src/views/business/restaurant-info/menu/MenusInfoPage.vue
@@ -1,0 +1,57 @@
+<script setup>
+import { ref, computed } from 'vue';
+import BusinessSidebar from '@/components/ui/BusinessSideBar.vue';
+import BusinessHeader from '@/components/ui/BusinessHeader.vue';
+import { ArrowLeft } from 'lucide-vue-next';
+import { useRouter, RouterLink } from 'vue-router';
+import { getMenuCategoriesByRestaurant } from '@/data/restaurantMenus';
+import RestaurantMenuList from '@/components/ui/RestaurantMenuList.vue';
+
+// Define props to receive the restaurant ID from the route
+const props = defineProps({
+  id: {
+    type: String,
+    required: true,
+  },
+});
+
+const router = useRouter();
+
+const goBack = () => {
+  router.back();
+};
+
+// Data fetching for menus
+const menuCategories = computed(() =>
+  getMenuCategoriesByRestaurant(props.id),
+);
+</script>
+
+<template>
+  <div class="flex h-screen bg-[#f8f9fa]">
+    <BusinessSidebar activeMenu="restaurant-info" />
+
+    <!-- Main Content -->
+    <div class="flex-1 flex flex-col overflow-hidden">
+      <BusinessHeader />
+
+      <!-- Scrollable Content Area -->
+      <main class="flex-1 overflow-y-auto p-8">
+        <div class="max-w-4xl mx-auto space-y-8">
+          <!-- Page Title and Back Button -->
+          <div class="flex items-center">
+            <button @click="goBack" class="mr-4 p-2 rounded-full hover:bg-gray-200">
+              <ArrowLeft class="w-6 h-6 text-[#1e3a5f]" />
+            </button>
+            <h2 class="text-3xl font-bold text-[#1e3a5f]">전체 메뉴 보기</h2>
+          </div>
+
+          <!-- Menu List Section -->
+          <section>
+            <RestaurantMenuList :menu-categories="menuCategories" />
+          </section>
+        </div>
+      </main>
+    </div>
+  </div>
+</template>

--- a/frontend/src/views/restaurant/id/menus/RestaurantMenusPage.vue
+++ b/frontend/src/views/restaurant/id/menus/RestaurantMenusPage.vue
@@ -2,8 +2,8 @@
 import { computed } from 'vue';
 import { RouterLink, useRoute } from 'vue-router';
 import { ArrowLeft } from 'lucide-vue-next';
-import Card from '@/components/ui/Card.vue';
 import { getMenuCategoriesByRestaurant } from '@/data/restaurantMenus';
+import RestaurantMenuList from '@/components/ui/RestaurantMenuList.vue';
 
 const route = useRoute();
 const restaurantId = computed(() => route.params.id || '1');
@@ -11,8 +11,6 @@ const restaurantId = computed(() => route.params.id || '1');
 const menuCategories = computed(() =>
   getMenuCategoriesByRestaurant(restaurantId.value),
 );
-
-const fallbackImage = '/placeholder.svg';
 </script>
 
 <template>
@@ -27,69 +25,9 @@ const fallbackImage = '/placeholder.svg';
     </header>
 
     <main class="max-w-[500px] mx-auto px-4 py-5 pb-8">
-      <template v-if="menuCategories.length">
-        <section
-          v-for="(category, idx) in menuCategories"
-          :key="category.id || idx"
-          class="mb-6"
-        >
-          <div class="flex items-center justify-between mb-3 px-1">
-            <h3 class="text-base font-semibold text-[#1e3a5f]">
-              {{ category.name }}
-            </h3>
-            <p class="text-xs text-[#adb5bd]">총 {{ category.items.length }}개</p>
-          </div>
-
-          <div class="space-y-3">
-            <Card
-              v-for="(item, itemIdx) in category.items"
-              :key="item.id || itemIdx"
-              class="p-3 border-[#e9ecef] rounded-xl bg-white shadow-card hover:shadow-md transition-shadow"
-            >
-              <div class="flex items-center gap-3">
-                <img
-                  :src="item.image || fallbackImage"
-                  :alt="item.name"
-                  class="w-20 h-20 rounded-lg object-cover flex-shrink-0"
-                />
-                <div class="flex-1 min-w-0">
-                  <div class="flex items-start justify-between gap-4">
-                    <p class="menu-title text-[#1e3a5f]">
-                      {{ item.name }}
-                    </p>
-                    <p class="font-semibold text-[#ff6b4a] whitespace-nowrap">
-                      {{ item.price }}
-                    </p>
-                  </div>
-                  <p
-                    v-if="item.description"
-                    class="text-xs text-[#6c757d] leading-relaxed mt-1"
-                  >
-                    {{ item.description }}
-                  </p>
-                </div>
-              </div>
-            </Card>
-          </div>
-        </section>
-      </template>
-
-      <div
-        v-else
-        class="py-20 text-center text-sm text-[#6c757d] bg-white rounded-2xl"
-      >
-        메뉴 정보가 곧 업데이트될 예정입니다.
-      </div>
+      <RestaurantMenuList :menu-categories="menuCategories" />
     </main>
   </div>
 </template>
 
-<style scoped>
-.menu-title {
-  font-weight: 600;
-  display: -webkit-box;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-</style>
+


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 식당메뉴 리스트 컴포넌트 분리
- 분리한 식당메뉴 리스트 컴포넌트를 활용한 사업자 전용 식당메뉴 조회 페이지 생성
- 식당정보 조회 페이지에서 '정기휴무일' 요소의 배치가 화면의 너비에 맞게 조정되지 않는 문제 수정

## 📁 변경된 파일

- frontend/src/components/ui/BusinessSideBar.vue (식당메뉴 조회 페이지로 연결될 수 있도록 식당정보 조회 페이지 라우팅 경로 수정)
- frontend/src/router/index.js (식당메뉴 조회 페이지 라우팅 경로 추가, 식당정보 조회 페이지 라우팅 경로 변경)
- frontend/src/components/ui/RestaurantMenuList.vue (식당메뉴 리스트에 관한 컴포넌트 분리)
- frontend/src/views/business/restaurant-info/RestaurantInfoPage.vue ('식당메뉴 전체보기' 클릭 시 식당메뉴 조회 페이지로 라우팅)
- frontend/src/views/restaurant/id/menus/RestaurantMenusPage.vue (분리한 컴포넌트 적용)

## 🔗 관련 Issue(선택)

- [식당메뉴 리스트 컴포넌트 분리 & 사업자 전용 식당 메뉴 전체보기 페이지 추가 #96](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/96)

## ✔️ 체크리스트(선택)

- 컴포넌트 분리 이후 일반 사용자용 식당 상세 페이지에 연결된 식당메뉴 조회 페이지 정상 출력 여부 확인(완료)
- 사업자 전용 식당정보 조회 페이지 내부의 식당메뉴 조회 페이지 정상 출력 여부 확인(완료)
