### PR TITLE
fix(restaurant): 식당정보 수정 완료 후 조회 페이지로 이동하지 못하는 문제 수정

### DIFF
--- a/frontend/src/views/business/restaurant-info/edit/RestaurantInfoEditPage.vue
+++ b/frontend/src/views/business/restaurant-info/edit/RestaurantInfoEditPage.vue
@@ -455,7 +455,16 @@ const saveRestaurant = async () => {
       console.log('Creating new restaurant:', dataToSubmit);
     }
     alert('저장되었습니다.');
-    router.push('/business/restaurant-info');
+    if (isEditMode.value) {
+      // 수정 모드일 경우, 현재 restaurantId를 사용하여 상세 페이지로 이동
+      router.push(`/business/restaurant-info/${route.params.id}`);
+    } else {
+      // 등록 모드일 경우, 새로운 restaurantId가 필요합니다.
+      // 현재 API가 실제 ID를 반환하지 않으므로, 임시로 1로 설정합니다.
+      // TODO: 실제 API 연동 시, 응답으로 받은 새 ID를 사용해야 합니다.
+      const newRestaurantId = 1;
+      router.push(`/business/restaurant-info/${newRestaurantId}`);
+    }
   } catch (error) {
     console.error('저장 실패:', error);
     alert('저장에 실패했습니다.');


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 식당정보 수정 완료 후 '수정하기' 버튼 클릭 시 식당정보 조회 페이지로 이동하도록 수정

## 📁 변경된 파일

- frontend/src/views/business/restaurant-info/edit/RestaurantInfoEditPage.vue

## 🔗 관련 Issue(선택)

- [식당정보 수정 완료 후 식당정보 조회 페이지로 이동하지 못하는 오류 수정 #99](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/99)

## ✔️ 체크리스트(선택)

- 식당정보 수정 완료 후 식당정보 조회 페이지로의 이동 여부 확인 (완료)
