### PR TITLE
feat(frontHeader): 사용자, 사업자, 관리자 로그인 전 후 헤더 수정 및 로그인 폼 수정

### DIFF
--- a/frontend/src/components/ui/AdminHeader.vue
+++ b/frontend/src/components/ui/AdminHeader.vue
@@ -1,6 +1,25 @@
 <script setup>
 import { User, Bell, LogOut } from 'lucide-vue-next';
-import { RouterLink } from 'vue-router';
+import { RouterLink, useRouter } from 'vue-router';
+
+const router = useRouter();
+
+const handleLogout = () => {
+  const confirmLogout = confirm('정말 로그아웃 하시겠습니까?');
+
+  if (confirmLogout) {
+    try {
+      // 여기에 실제 로그아웃 로직 작성 (예: Pinia action 호출, 토큰 삭제 등)
+      // await authStore.logout();
+      console.log('로그아웃 로직 실행됨');
+
+      // 로그아웃 후 첫 페이지로 이동
+      router.push('/');
+    } catch (error) {
+      console.error('로그아웃 실패:', error);
+    }
+  }
+};
 </script>
 
 <template>
@@ -20,13 +39,10 @@ import { RouterLink } from 'vue-router';
       </button>
       <div class="flex items-center gap-4">
         <span class="text-sm text-gray-600">관리자님 안녕하세요!</span>
-        <button
-          class="flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
-        >
-          <User class="w-4 h-4" />
-        </button>
+
         <div class="relative">
           <button
+            @click="handleLogout"
             class="flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
           >
             <span class="text-sm">로그아웃</span>

--- a/frontend/src/components/ui/AppHeader.vue
+++ b/frontend/src/components/ui/AppHeader.vue
@@ -1,0 +1,141 @@
+<script setup>
+import { ref } from 'vue';
+import { RouterLink, useRouter } from 'vue-router';
+
+const router = useRouter();
+
+// --- 상태 관리 --- (pinia 추후 연결)
+const isLoggedIn = ref(true); //일단 로그인 화면
+const userName = ref('김런치');
+const userProfileImage = ref(
+  'https://api.dicebear.com/9.x/avataaars/svg?seed=Felix'
+);
+const isMenuOpen = ref(false);
+
+// --- 핸들러 ---
+const toggleMenu = () => {
+  isMenuOpen.value = !isMenuOpen.value;
+};
+
+const handleLogout = async () => {
+  alert('로그아웃 되었습니다.');
+
+  //로그아웃 로직 구현
+  isLoggedIn.value = false;
+  isMenuOpen.value = false;
+  router.push('/');
+};
+</script>
+
+<template>
+  <header class="sticky top-0 z-50 bg-white border-b border-[#e9ecef]">
+    <div
+      class="max-w-[500px] mx-auto px-4 h-14 flex items-center justify-between"
+    >
+      <div class="flex items-center gap-3">
+        <img
+          src="/images/lunch-go-whitebg.png"
+          alt="런치고"
+          width="56"
+          height="56"
+          class="w-14 h-14 object-contain"
+        />
+        <RouterLink
+          to="/intro"
+          class="font-semibold text-[#1e3a5f] text-base hover:text-[#ff6b4a] transition-colors"
+        >
+          서비스 소개
+        </RouterLink>
+      </div>
+
+      <div class="flex items-center gap-4">
+        <template v-if="isLoggedIn">
+          <span class="text-sm font-medium text-[#495057]">
+            <span class="text-[#1e3a5f] font-bold">{{ userName }}</span
+            >님 안녕하세요!
+          </span>
+
+          <div class="relative">
+            <button
+              @click="toggleMenu"
+              class="flex items-center justify-center w-9 h-9 rounded-full overflow-hidden border border-gray-200 hover:ring-2 hover:ring-[#ff6b4a] transition-all focus:outline-none"
+            >
+              <img
+                :src="userProfileImage"
+                alt="프로필"
+                class="w-full h-full object-cover"
+              />
+            </button>
+
+            <Transition name="dropdown">
+              <div
+                v-if="isMenuOpen"
+                class="absolute right-0 top-full mt-2 w-max bg-white rounded-lg shadow-xl border border-gray-100 py-2 z-50"
+              >
+                <RouterLink
+                  to="/mypage"
+                  class="block px-4 py-2 text-sm text-center text-gray-700 hover:bg-gray-50 hover:text-[#ff6b4a] transition-colors"
+                  @click="isMenuOpen = false"
+                >
+                  마이페이지
+                </RouterLink>
+
+                <button
+                  @click="handleLogout"
+                  class="w-full text-center block px-4 py-2 text-sm text-red-500 hover:bg-red-50 transition-colors"
+                >
+                  로그아웃
+                </button>
+              </div>
+            </Transition>
+          </div>
+        </template>
+
+        <template v-else>
+          <RouterLink
+            to="/login"
+            class="text-sm text-[#495057] font-medium hover:text-[#ff6b4a] transition-colors"
+          >
+            로그인
+          </RouterLink>
+          <RouterLink
+            to="/signup"
+            class="text-sm text-[#495057] font-medium hover:text-[#ff6b4a] transition-colors"
+          >
+            회원가입
+          </RouterLink>
+        </template>
+      </div>
+    </div>
+  </header>
+</template>
+
+<style scoped>
+/* Vue Transition Classes 
+  name="dropdown"으로 설정했으므로 접두사가 dropdown- 입니다.
+*/
+
+/* 애니메이션 동작 시간 및 가속도 설정 (나타날 때 & 사라질 때) */
+.dropdown-enter-active,
+.dropdown-leave-active {
+  transition: all 0.2s ease-out;
+}
+
+/* 시작 상태 (Enter From) & 끝 상태 (Leave To) 
+  투명하고 살짝 위로 올라가 있음 
+*/
+.dropdown-enter-from,
+.dropdown-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+
+/* 완료 상태 (Enter To) & 시작 상태 (Leave From)
+  완전 불투명하고 제자리에 있음 
+*/
+.dropdown-enter-to,
+.dropdown-leave-from {
+  opacity: 1;
+  transform: translateY(0);
+}
+</style>

--- a/frontend/src/components/ui/BusinessHeader.vue
+++ b/frontend/src/components/ui/BusinessHeader.vue
@@ -1,6 +1,41 @@
 <script setup>
+import { ref } from 'vue'; // 상태 관리를 위해 ref 임포트
+import { useRouter } from 'vue-router'; // 페이지 이동을 위해 router 임포트
 import { User, Bell, LogOut } from 'lucide-vue-next';
 import { RouterLink } from 'vue-router';
+
+// --- Pinia 연동 부분 (예시) ---
+// const authStore = useAuthStore();
+// const userName = computed(() => authStore.user?.name || 'OOO');
+const userName = ref('김사장'); // 임시 데이터
+
+const router = useRouter();
+const isMenuOpen = ref(false); // 메뉴 열림/닫힘 상태
+
+// --- 메소드 ---
+
+// 1. 메뉴 토글 기능
+const toggleMenu = () => {
+  isMenuOpen.value = !isMenuOpen.value;
+};
+
+// 2. 로그아웃 기능
+const handleLogout = async () => {
+  const confirmLogout = confirm('정말 로그아웃 하시겠습니까?');
+
+  if (confirmLogout) {
+    try {
+      // 여기에 실제 로그아웃 로직 작성 (예: Pinia action 호출, 토큰 삭제 등)
+      // await authStore.logout();
+      console.log('로그아웃 로직 실행됨');
+
+      // 로그아웃 후 첫 페이지로 이동
+      router.push('/');
+    } catch (error) {
+      console.error('로그아웃 실패:', error);
+    }
+  }
+};
 </script>
 
 <template>
@@ -14,40 +49,25 @@ import { RouterLink } from 'vue-router';
         LunchGo
       </h1>
     </RouterLink>
+
     <div class="flex items-center gap-4">
       <button class="text-[#1e3a5f] hover:text-[#FF6B4A] transition-colors">
         <Bell class="w-6 h-6" />
       </button>
+
       <div class="flex items-center gap-4">
-        <span class="text-sm text-gray-600">OOO님 안녕하세요!</span>
+        <span class="text-sm text-gray-600">
+          <span class="text-[#1e3a5f] font-bold">{{ userName }}</span
+          >님 안녕하세요!
+        </span>
+
         <button
-          class="flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
+          @click="handleLogout"
+          class="flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg hover:bg-red-50 hover:text-red-500 hover:border-red-200 transition-colors"
         >
-          <User class="w-4 h-4" />
+          <span class="text-sm">로그아웃</span>
+          <LogOut class="w-4 h-4" />
         </button>
-        <div class="relative">
-          <button
-            class="flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
-          >
-            <span class="text-sm">로그아웃</span>
-            <LogOut class="w-4 h-4" />
-          </button>
-          <!-- This dropdown logic needs to be implemented in Vue if it's functional -->
-          <div
-            class="absolute top-full right-0 mt-2 bg-white border border-gray-200 rounded-lg shadow-lg p-2 min-w-[120px] hidden group-hover:block"
-          >
-            <button
-              class="block w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded"
-            >
-              마이페이지
-            </button>
-            <button
-              class="block w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded"
-            >
-              식당 정보
-            </button>
-          </div>
-        </div>
       </div>
     </div>
   </header>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -29,6 +29,7 @@ import BottomNav from '@/components/ui/BottomNav.vue';
 import { RouterLink } from 'vue-router'; // Import Vue RouterLink
 import { loadKakaoMaps, geocodeAddress } from '@/utils/kakao';
 import { restaurants as restaurantData } from '@/data/restaurants';
+import AppHeader from '@/components/ui/AppHeader.vue';
 
 // State management (React's useState -> Vue's ref)
 const isFilterOpen = ref(false);
@@ -729,42 +730,7 @@ const closeMapRestaurantModal = () => {
 
 <template>
   <div class="min-h-screen bg-[#f8f9fa]">
-    <header class="sticky top-0 z-50 bg-white border-b border-[#e9ecef]">
-      <div
-        class="max-w-[500px] mx-auto px-4 h-14 flex items-center justify-between"
-      >
-        <div class="flex items-center gap-3">
-          <!-- Next.js Image component replaced with standard <img> -->
-          <img
-            src="/images/lunch-go-whitebg.png"
-            alt="런치고"
-            width="56"
-            height="56"
-            class="w-14 h-14"
-          />
-          <RouterLink
-            to="/intro"
-            class="font-semibold text-[#1e3a5f] text-base hover:text-[#ff6b4a] transition-colors"
-          >
-            서비스 소개
-          </RouterLink>
-        </div>
-        <div class="flex items-center gap-4">
-          <RouterLink
-            to="/login"
-            class="text-sm text-[#495057] font-medium hover:text-[#ff6b4a] transition-colors"
-          >
-            로그인
-          </RouterLink>
-          <RouterLink
-            to="/signup"
-            class="text-sm text-[#495057] font-medium hover:text-[#ff6b4a] transition-colors"
-          >
-            회원가입
-          </RouterLink>
-        </div>
-      </div>
-    </header>
+    <AppHeader />
 
     <main class="max-w-[500px] mx-auto pb-20">
       <div class="bg-white px-4 py-4 border-b border-[#e9ecef]">

--- a/frontend/src/views/signup/UserSignupPage.vue
+++ b/frontend/src/views/signup/UserSignupPage.vue
@@ -171,7 +171,10 @@ onUnmounted(() => {
 });
 
 const checkInputElement = () => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!email.value) return alert('이메일을 입력해주세요.');
+  if (!emailRegex.test(email.value))
+    return alert('이메일 양식에 맞지 않습니다.');
   if (!isEmailUnique.value) return alert('이메일 중복확인이 필요합니다.');
   if (!password.value) return alert('비밀번호를 입력해주세요.');
   if (!passwordConfirm.value) return alert('비밀번호 재입력이 필요합니다.');


### PR DESCRIPTION
## 📌 작업 내용 
- 로그인 전에는 로그인, 회원가입 헤더이고, 로그인 후 안녕하세요! 및 로그아웃이 뜨도록 수정
- 로그인 유효성 검사 추가
- 현재 로그인 시 각자 경로 들어갈 수 있도록 수정

## 📁 변경된 파일
- AdminHeader.vue
- BusinessHeader.vue
- AppHeader.vue
- HomeView.vue
- LoginPage.vue

## 🔗 관련 Issue(선택)
- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/122

## ✔️ 체크리스트(선택)
- 사용자는 이메일 양식만 지켜서 로그인해보시면 됩니다
- 사업자와 관리자도 아이디와 비밀번호 양식만 지켜서 로그인해보시면 페이지가 이동합니다
