### PR TITLE
fix(restaurant): 식당메뉴 등록/수정 페이지 -> 식당정보 등록/수정 페이지 복귀 시 변경 내역 유지

### DIFF
--- a/frontend/src/views/business/restaurant-info/edit/RestaurantInfoEditPage.vue
+++ b/frontend/src/views/business/restaurant-info/edit/RestaurantInfoEditPage.vue
@@ -513,6 +513,18 @@ watch(formData, (newState) => {
   if (newState.description) validationErrors.description = '';
 });
 
+// formData의 변경을 감지하여 Pinia store에 동기화
+watch(
+  formData,
+  (newData) => {
+    // store.restaurantInfo가 존재할 때만 동기화
+    if (store.restaurantInfo) {
+      Object.assign(store.restaurantInfo, newData);
+    }
+  },
+  { deep: true }
+);
+
 watch(restaurantImageFile, (newFile) => {
   if (newFile) validationErrors.image = '';
 });


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 식당메뉴 등록/수정 페이지에서 식당정보 등록/수정 페이지로 이동할 때 한정으로 작성중인 내역을 보존하는 프론트 기능 미적용 문제 수정

## 📁 변경된 파일

- frontend/src/views/business/restaurant-info/edit/RestaurantInfoEditPage.vue

## 🔗 관련 Issue(선택)

- [[FEATURE] 식당정보 등록 페이지 세부사항 수정 #132
](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/132)
