### PR TITLE
feat(restaurant): 식당 관련 DB 테이블 속성 타입 수정

### DIFF
--- a/frontend/src/views/business/restaurant-info/edit/RestaurantInfoEditPage.vue
+++ b/frontend/src/views/business/restaurant-info/edit/RestaurantInfoEditPage.vue
@@ -378,7 +378,7 @@ const saveRestaurant = async () => {
   } else {
     // 유효한 접두사와 전화번호 형식을 모두 검사하는 정규식
     const phoneRegex =
-      /^(02|010|011|01[6-9]|03[1-3]|04[1-4]|05[1-5]|06[1-4]|070|080|050)-\d{3,4}-\d{4}$/;
+      /^(02|010|011|01[6-9]|03[1-3]|04[1-4]|05[1-5]|06[1-4]|070|080|050[0-9]|050)-\d{3,4}-\d{4}$/;
     if (!phoneRegex.test(formData.phone)) {
       validationErrors.phone =
         '유효하지 않은 전화번호 형식 또는 지역번호입니다.';
@@ -631,7 +631,7 @@ watch(paginatedMenus, (newPaginatedMenus) => {
                     type="tel"
                     placeholder="하이픈(-)을 포함하여 입력하세요"
                     v-model="formData.phone"
-                    maxlength="13"
+                    maxlength="15"
                     class="w-full px-4 py-3 border border-[#dee2e6] rounded-lg focus:outline-none focus:ring-2 focus:ring-[#FF6B4A]"
                   />
                   <p

--- a/src/main/resources/sql/tables_create_restaurant_info.sql
+++ b/src/main/resources/sql/tables_create_restaurant_info.sql
@@ -20,11 +20,11 @@ CREATE TABLE restaurants
     restaurant_id      BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '식당 ID',
     owner_id           BIGINT       NOT NULL COMMENT '사업자(점주) ID',
     name               VARCHAR(50)  NOT NULL COMMENT '식당명',
-    phone              VARCHAR(13)  NOT NULL COMMENT '식당전화번호',
+    phone              VARCHAR(15)  NOT NULL COMMENT '식당전화번호',
     road_address       VARCHAR(255) NOT NULL COMMENT '도로명주소',
     detail_address     VARCHAR(255) NOT NULL COMMENT '상세주소',
     status             VARCHAR(50) DEFAULT 'OPEN' COMMENT '운영상태',
-    description        VARCHAR(255) COMMENT '식당소개문',
+    description        TEXT COMMENT '식당소개문',
     avg_main_price     INT          NOT NULL COMMENT '주메뉴 평균가',
     reservation_limit  INT          NOT NULL COMMENT '예약가능인원 상한',
     holiday_available  TINYINT(1)  DEFAULT 0 COMMENT '공휴일 운영 여부 (0:false, 1:true)',
@@ -35,7 +35,7 @@ CREATE TABLE restaurants
     created_at         DATETIME    DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
     updated_at         DATETIME    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
 
-    CONSTRAINT chk_phone_format CHECK (phone REGEXP '^[0-9]{2,3}-[0-9]{3,4}-[0-9]{4}$'),
+    CONSTRAINT chk_phone_format CHECK (phone REGEXP '^(050[0-9]|[0-9]{2,3})-[0-9]{3,4}-[0-9]{4}$'),
     CONSTRAINT chk_restaurant_status CHECK (status IN ('OPEN', 'CLOSED', 'DELETED'))
 ) COMMENT '식당 정보';
 
@@ -44,7 +44,7 @@ CREATE TABLE restaurant_images
 (
     restaurant_image_id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '식당이미지ID',
     restaurant_id       BIGINT       NOT NULL COMMENT '식당ID',
-    image_url           TEXT NOT NULL COMMENT '식당이미지 URL'
+    image_url           LONGTEXT NOT NULL COMMENT '식당이미지 URL'
 ) COMMENT '식당 이미지';
 
 -- 4. 식당 메뉴
@@ -65,7 +65,7 @@ CREATE TABLE menu_images
 (
     menu_image_id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '식당메뉴이미지ID',
     menu_id       BIGINT       NOT NULL COMMENT '식당메뉴ID',
-    image_url     TEXT NOT NULL COMMENT '식당메뉴이미지 URL'
+    image_url     LONGTEXT NOT NULL COMMENT '식당메뉴이미지 URL'
 ) COMMENT '식당 메뉴 이미지';
 
 -- 6. 식당-태그 매핑 (복합키 이름 지정: pk_restaurant_tag_map)


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

(아래 테이블들의 속성 타입을 변경합니다. 변경한 내용은 erdcloud에도 반영합니다.)

* 식당(`restaurants`) 테이블
  - 식당전화번호(`phone`) : 안심번호(맨 앞자리 050X로 시작)를 사용하는 식당으로 인해 varchar(13)에서 varchar(15)로 수정
    - 전화번호 관련 check 제약조건 수정
    - 프론트엔드 화면에서의 전화번호 관련 유효성 검사 규칙도 변경
  - 식당소개문(`description`) : varchar(255)에서 TEXT로 타입 변경

* 식당이미지(`restaurant_images`) 테이블
  - image_url: url 주소가 길어질 수 있어 TEXT에서 LONGTEXT로 타입 변경

* 식당메뉴이미지(`menu_images`) 테이블
  - image_url: url 주소가 길어질 수 있어 TEXT에서 LONGTEXT로 타입 변경

* 식당메뉴 테이블에 아래 속성을 새로 추가합니다.
  - is_deleted(삭제여부) :  tinyint(1) 타입으로 지정 - soft delete를 수행하기 위해 필요

## 📁 변경된 파일

- frontend/src/views/business/restaurant-info/edit/RestaurantInfoEditPage.vue
- src/main/resources/sql/tables_create_restaurant_info.sql

## 공유사항 to 리뷰어 <!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요.-->

- 백엔드 서버를 실행하려고 할 때, ocr에 관한 키가 없는 문제로 인해 ocrController, ocrService에서 에러가 발생하여 실제 실행 시에는 두 클래스를 일단 주석 처리했습니다.

## 🔗 관련 Issue(선택)

- [[FEATURE] 식당 테이블의 일부 속성 타입 변경 #150](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/150)

## ✔️ 체크리스트(선택)

- 식당 관련 테이블 속성 타입 변경 이후 테이블 생성문 정상 실행
- 안심번호를 사용하는 식당전화번호에 관한 변경된 유효성 검사 규칙 적용 여부 확인 (완료)
  - 050X로 시작하는 전화번호는 유효, 그 외(0511, 0510 등)는 유효하지 않음
