### PR TITLE
feat(join): 사업자 회원가입 로직 및 아이디,이메일 중복 확인 구현

### DIFF
--- a/src/main/java/com/example/LunchGo/account/controller/AccountController.java
+++ b/src/main/java/com/example/LunchGo/account/controller/AccountController.java
@@ -1,5 +1,6 @@
 package com.example.LunchGo.account.controller;
 
+import com.example.LunchGo.account.dto.OwnerJoinRequest;
 import com.example.LunchGo.account.dto.UserJoinRequest;
 import com.example.LunchGo.account.helper.AccountHelper;
 import lombok.RequiredArgsConstructor;
@@ -7,17 +8,16 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @Log4j2
+@RequestMapping("/api")
 public class AccountController {
     private final AccountHelper accountHelper;
 
-    @PostMapping("/api/join/user")
+    @PostMapping("/join/user")
     public ResponseEntity<?> userJoin(@RequestBody UserJoinRequest userReq) {
         if(!StringUtils.hasLength(userReq.getEmail()) || !StringUtils.hasLength(userReq.getPassword()) || !StringUtils.hasLength(userReq.getName()) ||
            !StringUtils.hasLength(userReq.getPhone()) || !StringUtils.hasLength(userReq.getCompanyName()) || !StringUtils.hasLength(userReq.getCompanyAddress())) {
@@ -28,4 +28,33 @@ public class AccountController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @PostMapping("/auth/email")
+    public ResponseEntity<?> checkEmail(@RequestBody UserJoinRequest userReq) {
+        if(!StringUtils.hasLength(userReq.getEmail())) { //이메일 검증이니 이메일만 체크
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+        accountHelper.checkEmail(userReq.getEmail()); //존재하면 여기서 409 에러 던짐
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PostMapping("/join/owner")
+    public ResponseEntity<?> ownerJoin(@RequestBody OwnerJoinRequest ownerReq) {
+        if(!StringUtils.hasLength(ownerReq.getLoginId()) || !StringUtils.hasLength(ownerReq.getPassword()) || !StringUtils.hasLength(ownerReq.getName()) ||
+            !StringUtils.hasLength(ownerReq.getPhone()) || !StringUtils.hasLength(ownerReq.getBusinessNum())){
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        accountHelper.ownerJoin(ownerReq);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PostMapping("/auth/loginId")
+    public ResponseEntity<?> checkLoginId(@RequestBody OwnerJoinRequest ownerReq) {
+        if(!StringUtils.hasLength(ownerReq.getLoginId())) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        accountHelper.checkLoginId(ownerReq.getLoginId());
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/LunchGo/account/dto/OwnerJoinRequest.java
+++ b/src/main/java/com/example/LunchGo/account/dto/OwnerJoinRequest.java
@@ -1,0 +1,17 @@
+package com.example.LunchGo.account.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class OwnerJoinRequest {
+    private String loginId;
+    private String password;
+    private String name;
+    private String phone;
+    private LocalDate startAt;
+    private String businessNum;
+}

--- a/src/main/java/com/example/LunchGo/account/helper/AccountHelper.java
+++ b/src/main/java/com/example/LunchGo/account/helper/AccountHelper.java
@@ -1,8 +1,15 @@
 package com.example.LunchGo.account.helper;
 
+import com.example.LunchGo.account.dto.OwnerJoinRequest;
 import com.example.LunchGo.account.dto.UserJoinRequest;
 
 public interface AccountHelper {
 
     void userJoin(UserJoinRequest userReq);
+
+    void checkEmail(String email);
+
+    void ownerJoin(OwnerJoinRequest userReq);
+
+    void checkLoginId(String loginId);
 }

--- a/src/main/java/com/example/LunchGo/account/helper/AccountHelperImpl.java
+++ b/src/main/java/com/example/LunchGo/account/helper/AccountHelperImpl.java
@@ -1,5 +1,6 @@
 package com.example.LunchGo.account.helper;
 
+import com.example.LunchGo.account.dto.OwnerJoinRequest;
 import com.example.LunchGo.account.dto.UserJoinRequest;
 import com.example.LunchGo.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +19,20 @@ public class AccountHelperImpl implements AccountHelper {
     @Override
     public void userJoin(UserJoinRequest userReq) {
         memberService.save(userReq); //회원가입
+    }
+
+    @Override
+    public void checkEmail(String email) {
+        memberService.existsByEmail(email);
+    }
+
+    @Override
+    public void ownerJoin(OwnerJoinRequest ownerReq) {
+        memberService.save(ownerReq);
+    }
+
+    @Override
+    public void checkLoginId(String loginId) {
+        memberService.existsByLoginId(loginId);
     }
 }

--- a/src/main/java/com/example/LunchGo/member/domain/OwnerStatus.java
+++ b/src/main/java/com/example/LunchGo/member/domain/OwnerStatus.java
@@ -1,0 +1,7 @@
+package com.example.LunchGo.member.domain;
+
+public enum OwnerStatus {
+    PENDING,
+    ACTIVE,
+    WITHDRAWAL
+}

--- a/src/main/java/com/example/LunchGo/member/entity/Owner.java
+++ b/src/main/java/com/example/LunchGo/member/entity/Owner.java
@@ -1,0 +1,84 @@
+package com.example.LunchGo.member.entity;
+
+import com.example.LunchGo.member.domain.CustomRole;
+import com.example.LunchGo.member.domain.OwnerStatus;
+import com.example.LunchGo.member.domain.UserStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "owners")
+public class Owner {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "owner_id")
+    private Long ownerId;
+
+    @Column(name = "login_id", nullable = false, length = 50, unique = true)
+    private String loginId;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+
+    @Column(name = "business_num", nullable = false, length = 30)
+    private String businessNum;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "phone", nullable = false, length = 20)
+    private String phone;
+
+    @Column(name = "image", length = 255)
+    private String image;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private OwnerStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    private CustomRole role;
+
+    @Column(name = "start_at", nullable = false)
+    private LocalDate startAt;
+
+    @Column(name = "created_at", nullable = false)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @Column(name = "withdrawal_at")
+    private LocalDateTime withdrawalAt;
+
+    @Builder
+    public Owner(String loginId, String password, String businessNum, String name,
+                 String phone, LocalDate startAt,
+                 OwnerStatus status, CustomRole role) {
+        this.loginId = loginId;
+        this.password = password;
+        this.businessNum = businessNum;
+        this.name = name;
+        this.phone = phone;
+        this.startAt = startAt;
+        this.status = status;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/example/LunchGo/member/repository/OwnerRepository.java
+++ b/src/main/java/com/example/LunchGo/member/repository/OwnerRepository.java
@@ -1,0 +1,11 @@
+package com.example.LunchGo.member.repository;
+
+import com.example.LunchGo.member.entity.Owner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OwnerRepository extends JpaRepository<Owner, Long> {
+    /**
+     * 이미 존재하는 아이디인지 확인
+     * */
+    boolean existsByLoginId(String loginId);
+}

--- a/src/main/java/com/example/LunchGo/member/service/BaseMemberService.java
+++ b/src/main/java/com/example/LunchGo/member/service/BaseMemberService.java
@@ -1,9 +1,13 @@
 package com.example.LunchGo.member.service;
 
+import com.example.LunchGo.account.dto.OwnerJoinRequest;
 import com.example.LunchGo.account.dto.UserJoinRequest;
 import com.example.LunchGo.member.domain.CustomRole;
+import com.example.LunchGo.member.domain.OwnerStatus;
 import com.example.LunchGo.member.domain.UserStatus;
+import com.example.LunchGo.member.entity.Owner;
 import com.example.LunchGo.member.entity.User;
+import com.example.LunchGo.member.repository.OwnerRepository;
 import com.example.LunchGo.member.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -16,14 +20,10 @@ import org.springframework.web.server.ResponseStatusException;
 @Log4j2
 public class BaseMemberService implements MemberService {
     private final UserRepository userRepository;
+    private final OwnerRepository ownerRepository;
 
     @Override
     public void save(UserJoinRequest userReq) {
-
-        if(userRepository.existsByEmail(userReq.getEmail())) {
-            log.info("User already exists with email: " + userReq.getEmail());
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
-        }
         userRepository.save(User.builder()
                 .email(userReq.getEmail())
                 .password(userReq.getPassword()) //암호화 필수
@@ -36,5 +36,35 @@ public class BaseMemberService implements MemberService {
                         .emailAuthentication(false) //기본값
                         .status(UserStatus.ACTIVE) //기본값
                 .build());
+    }
+
+    @Override
+    public void existsByEmail(String email) {
+        if(userRepository.existsByEmail(email)) {
+            log.info("User already exists with email: " + email);
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
+        }
+    }
+
+    @Override
+    public void save(OwnerJoinRequest ownerReq) {
+        ownerRepository.save(Owner.builder()
+                .loginId(ownerReq.getLoginId())
+                .password(ownerReq.getPassword())
+                .name(ownerReq.getName())
+                .startAt(ownerReq.getStartAt())
+                .businessNum(ownerReq.getBusinessNum())
+                .phone(ownerReq.getPhone())
+                .role(CustomRole.OWNER)
+                .status(OwnerStatus.PENDING)
+                .build());
+    }
+
+    @Override
+    public void existsByLoginId(String loginId) {
+        if(ownerRepository.existsByLoginId(loginId)) {
+            log.info("User already exists with loginId: " + loginId);
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다.");
+        }
     }
 }

--- a/src/main/java/com/example/LunchGo/member/service/MemberService.java
+++ b/src/main/java/com/example/LunchGo/member/service/MemberService.java
@@ -1,9 +1,14 @@
 package com.example.LunchGo.member.service;
 
+import com.example.LunchGo.account.dto.OwnerJoinRequest;
 import com.example.LunchGo.account.dto.UserJoinRequest;
 
 public interface MemberService {
     void save(UserJoinRequest userReq);
 
+    void existsByEmail(String email);
 
+    void save(OwnerJoinRequest ownerReq);
+
+    void existsByLoginId(String loginId);
 }


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 사업자 회원가입 로직 구현
- 사용자의 경우, 이메일 중복 확인 버튼 존재로 인한 중복확인 로직만 메소드로 따로 분리
- 사업자 회원가입 전, 아이디 중복 확인 로직 메소드 분리

## 📁 변경된 파일

- account 폴더
- member 폴더

## 🔗 관련 Issue(선택)

- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/159

## ✔️ 체크리스트(선택)

- 사용자, 사업자 회원가입 postman 테스트 완료, 이메일/아이디 중복 확인 postman 테스트 완료
