### PR TITLE
feat(login): 이메일 및 아이디 찾기 로직 구현

### DIFF
--- a/src/main/java/com/example/LunchGo/account/controller/AccountController.java
+++ b/src/main/java/com/example/LunchGo/account/controller/AccountController.java
@@ -1,6 +1,8 @@
 package com.example.LunchGo.account.controller;
 
+import com.example.LunchGo.account.dto.OwnerFindRequest;
 import com.example.LunchGo.account.dto.OwnerJoinRequest;
+import com.example.LunchGo.account.dto.UserFindRequest;
 import com.example.LunchGo.account.dto.UserJoinRequest;
 import com.example.LunchGo.account.helper.AccountHelper;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +11,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -56,5 +61,32 @@ public class AccountController {
 
         accountHelper.checkLoginId(ownerReq.getLoginId());
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PostMapping("/auth/search/email")
+    public ResponseEntity<?> searchEmail(@RequestBody UserFindRequest userReq) {
+        if(!StringUtils.hasLength(userReq.getName()) || !StringUtils.hasLength(userReq.getPhone()) || !StringUtils.hasLength(userReq.getVerifyCode())){
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        String findEmail = accountHelper.getEmail(userReq);
+
+        Map<String, String> response = Collections.singletonMap("email", findEmail); //찾은 이메일 객체에 담아 보내기
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PostMapping("/auth/search/loginId")
+    public ResponseEntity<?> searchLoginId(@RequestBody OwnerFindRequest ownerReq) {
+        if(!StringUtils.hasLength(ownerReq.getName()) || !StringUtils.hasLength(ownerReq.getBusinessNum()) || !StringUtils.hasLength(ownerReq.getPhone()) ||
+                !StringUtils.hasLength(ownerReq.getVerifyCode())){
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        String findLoginId = accountHelper.getLoginId(ownerReq);
+
+        Map<String, String> response = Collections.singletonMap("loginId", findLoginId); //찾은 아이디 객체에 담아 보내기
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/LunchGo/account/dto/OwnerFindRequest.java
+++ b/src/main/java/com/example/LunchGo/account/dto/OwnerFindRequest.java
@@ -1,0 +1,13 @@
+package com.example.LunchGo.account.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OwnerFindRequest {
+    private String name;
+    private String businessNum;
+    private String phone;
+    private String verifyCode;
+}

--- a/src/main/java/com/example/LunchGo/account/dto/UserFindRequest.java
+++ b/src/main/java/com/example/LunchGo/account/dto/UserFindRequest.java
@@ -1,0 +1,12 @@
+package com.example.LunchGo.account.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserFindRequest {
+    private String name;
+    private String phone;
+    private String verifyCode;
+}

--- a/src/main/java/com/example/LunchGo/account/helper/AccountHelper.java
+++ b/src/main/java/com/example/LunchGo/account/helper/AccountHelper.java
@@ -1,6 +1,8 @@
 package com.example.LunchGo.account.helper;
 
+import com.example.LunchGo.account.dto.OwnerFindRequest;
 import com.example.LunchGo.account.dto.OwnerJoinRequest;
+import com.example.LunchGo.account.dto.UserFindRequest;
 import com.example.LunchGo.account.dto.UserJoinRequest;
 
 public interface AccountHelper {
@@ -12,4 +14,8 @@ public interface AccountHelper {
     void ownerJoin(OwnerJoinRequest userReq);
 
     void checkLoginId(String loginId);
+
+    String getEmail(UserFindRequest userReq);
+
+    String getLoginId(OwnerFindRequest ownerReq);
 }

--- a/src/main/java/com/example/LunchGo/account/helper/AccountHelperImpl.java
+++ b/src/main/java/com/example/LunchGo/account/helper/AccountHelperImpl.java
@@ -1,7 +1,11 @@
 package com.example.LunchGo.account.helper;
 
+import com.example.LunchGo.account.dto.OwnerFindRequest;
 import com.example.LunchGo.account.dto.OwnerJoinRequest;
+import com.example.LunchGo.account.dto.UserFindRequest;
 import com.example.LunchGo.account.dto.UserJoinRequest;
+import com.example.LunchGo.member.entity.Owner;
+import com.example.LunchGo.member.entity.User;
 import com.example.LunchGo.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -34,5 +38,21 @@ public class AccountHelperImpl implements AccountHelper {
     @Override
     public void checkLoginId(String loginId) {
         memberService.existsByLoginId(loginId);
+    }
+
+    @Override
+    public String getEmail(UserFindRequest userReq) {
+        //인증번호 전송 및 확인 로직
+
+        User user = memberService.find(userReq.getName(), userReq.getPhone()); //없으면 404처리 완료
+        return user.getEmail();
+    }
+
+    @Override
+    public String getLoginId(OwnerFindRequest ownerReq) {
+        //인증번호 전송 및 확인 로직
+
+        Owner owner = memberService.find(ownerReq.getName(), ownerReq.getBusinessNum(), ownerReq.getPhone());
+        return owner.getLoginId();
     }
 }

--- a/src/main/java/com/example/LunchGo/member/repository/OwnerRepository.java
+++ b/src/main/java/com/example/LunchGo/member/repository/OwnerRepository.java
@@ -3,9 +3,16 @@ package com.example.LunchGo.member.repository;
 import com.example.LunchGo.member.entity.Owner;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OwnerRepository extends JpaRepository<Owner, Long> {
     /**
      * 이미 존재하는 아이디인지 확인
      * */
     boolean existsByLoginId(String loginId);
+
+    /**
+     * name, businessNum, phone으로 아이디 찾기
+     * */
+    Optional<Owner> findByNameAndBusinessNumAndPhone(String name, String businessNum, String phone);
 }

--- a/src/main/java/com/example/LunchGo/member/repository/UserRepository.java
+++ b/src/main/java/com/example/LunchGo/member/repository/UserRepository.java
@@ -3,9 +3,16 @@ package com.example.LunchGo.member.repository;
 import com.example.LunchGo.member.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
     /**
      * 이미 존재하는 이메일인지 확인
      */
     boolean existsByEmail(String email);
+
+    /**
+     * name과 phone으로 사용자 email 찾기
+     * */
+    Optional<User> findByNameAndPhone(String name, String phone);
 }

--- a/src/main/java/com/example/LunchGo/member/service/BaseMemberService.java
+++ b/src/main/java/com/example/LunchGo/member/service/BaseMemberService.java
@@ -15,6 +15,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Log4j2
@@ -28,19 +30,19 @@ public class BaseMemberService implements MemberService {
                 .email(userReq.getEmail())
                 .password(userReq.getPassword()) //암호화 필수
                 .name(userReq.getName())
-                        .companyName(userReq.getCompanyName())
-                        .companyAddress(userReq.getCompanyAddress())
-                        .phone(userReq.getPhone())
-                        .marketingAgree(userReq.getMarketingAgree())
-                        .role(CustomRole.USER)
-                        .emailAuthentication(false) //기본값
-                        .status(UserStatus.ACTIVE) //기본값
+                .companyName(userReq.getCompanyName())
+                .companyAddress(userReq.getCompanyAddress())
+                .phone(userReq.getPhone())
+                .marketingAgree(userReq.getMarketingAgree())
+                .role(CustomRole.USER)
+                .emailAuthentication(false) //기본값
+                .status(UserStatus.ACTIVE) //기본값
                 .build());
     }
 
     @Override
     public void existsByEmail(String email) {
-        if(userRepository.existsByEmail(email)) {
+        if (userRepository.existsByEmail(email)) {
             log.info("User already exists with email: " + email);
             throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
         }
@@ -62,9 +64,23 @@ public class BaseMemberService implements MemberService {
 
     @Override
     public void existsByLoginId(String loginId) {
-        if(ownerRepository.existsByLoginId(loginId)) {
+        if (ownerRepository.existsByLoginId(loginId)) {
             log.info("User already exists with loginId: " + loginId);
             throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다.");
         }
+    }
+
+    @Override
+    public User find(String name, String phone) {
+        return userRepository.findByNameAndPhone(name, phone).orElseThrow( () ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 이메일을 가진 사용자가 없습니다."
+                ));
+
+    }
+
+    @Override
+    public Owner find(String name, String businessNum, String phone) {
+        return ownerRepository.findByNameAndBusinessNumAndPhone(name, businessNum, phone)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 아이디를 가진 사업자가 없습니다."));
     }
 }

--- a/src/main/java/com/example/LunchGo/member/service/MemberService.java
+++ b/src/main/java/com/example/LunchGo/member/service/MemberService.java
@@ -2,6 +2,8 @@ package com.example.LunchGo.member.service;
 
 import com.example.LunchGo.account.dto.OwnerJoinRequest;
 import com.example.LunchGo.account.dto.UserJoinRequest;
+import com.example.LunchGo.member.entity.Owner;
+import com.example.LunchGo.member.entity.User;
 
 public interface MemberService {
     void save(UserJoinRequest userReq);
@@ -11,4 +13,8 @@ public interface MemberService {
     void save(OwnerJoinRequest ownerReq);
 
     void existsByLoginId(String loginId);
+
+    User find(String name, String phone);
+
+    Owner find(String name, String businessNum, String phone);
 }


### PR DESCRIPTION
## 📌 작업 내용 

- 사용자 로그인 페이지에서 이메일 찾기 모달을 띄워 처리하는 이메일 찾기 구현
- 사업자 로그인 페이지에서 아이디 찾기 모달을 띄워 처리하는 아이디 찾기 구현

## 📁 변경된 파일

- account 폴더
- member 폴더

## 🔗 관련 Issue(선택)

- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/162

## ✔️ 체크리스트(선택)

- 인증번호 처리 로직을 넣어서 인증번호 일치/불일치 관련 로직 추가 필요
- postman 테스트 각각 완료
