### PR TITLE
feat(promotion): 사업자 프로모션 등록 및 메일 전송 로직 구현

### DIFF
--- a/src/main/java/com/example/LunchGo/common/config/AsyncConfig.java
+++ b/src/main/java/com/example/LunchGo/common/config/AsyncConfig.java
@@ -1,4 +1,24 @@
 package com.example.LunchGo.common.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
 public class AsyncConfig {
+    //비동기 기능 켜기
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("Email-Promotion-Async-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/example/LunchGo/email/dto/PromotionDTO.java
+++ b/src/main/java/com/example/LunchGo/email/dto/PromotionDTO.java
@@ -1,4 +1,10 @@
 package com.example.LunchGo.email.dto;
 
+import lombok.Data;
+
+@Data
 public class PromotionDTO {
+    private Long ownerId;
+    private String title;
+    private String content;
 }

--- a/src/main/java/com/example/LunchGo/email/service/EmailService.java
+++ b/src/main/java/com/example/LunchGo/email/service/EmailService.java
@@ -1,7 +1,10 @@
 package com.example.LunchGo.email.service;
 
+import com.example.LunchGo.email.dto.PromotionDTO;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+
+import java.util.List;
 
 public interface EmailService {
     String createCode();
@@ -13,4 +16,12 @@ public interface EmailService {
     void sendEmail(String toEmail) throws MessagingException;
 
     Boolean verifyEmailCode(String email, String code);
+
+    String setPromotionContext(String promotionContext);
+
+    MimeMessage createPromotionEmail(String title, String content, String email) throws MessagingException;
+
+    void checkAndLockPromotion(PromotionDTO promotionDTO);
+
+    void sendPromotionAsync(List<String> emails, PromotionDTO promotionDTO);
 }

--- a/src/main/java/com/example/LunchGo/member/mapper/MemberMapper.java
+++ b/src/main/java/com/example/LunchGo/member/mapper/MemberMapper.java
@@ -29,4 +29,9 @@ public interface MemberMapper {
     void deleteUserSpecialities(@Param("userId") Long userId);
 
     void insertUserSpecialities(@Param("userId") Long userId, @Param("specialityIds") List<Long> specialityIds);
+
+    /**
+     * 사업자가 프로모션 보낼 시, 즐겨찾기 등록한 사용자 email 알아야함
+     * */
+    List<String> getPromotionEmails(@Param("ownerId") Long ownerId);
 }

--- a/src/main/java/com/example/LunchGo/member/service/BaseMemberService.java
+++ b/src/main/java/com/example/LunchGo/member/service/BaseMemberService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -149,5 +150,14 @@ public class BaseMemberService implements MemberService {
         if(info.getSpecialities() != null && !info.getSpecialities().isEmpty()) {
             memberMapper.insertUserSpecialities(userId, info.getSpecialities()); //변경, 신규, 삭제로 인한 변경 추가
         }
+    }
+
+    @Override
+    public List<String> getEmails(Long ownerId) {
+        List<String> emails = memberMapper.getPromotionEmails(ownerId);
+
+        if(emails == null) throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사업자를 찾을 수 없습니다.");
+
+        return emails;
     }
 }

--- a/src/main/java/com/example/LunchGo/member/service/MemberService.java
+++ b/src/main/java/com/example/LunchGo/member/service/MemberService.java
@@ -8,6 +8,8 @@ import com.example.LunchGo.member.dto.MemberUpdateInfo;
 import com.example.LunchGo.member.entity.Owner;
 import com.example.LunchGo.member.entity.User;
 
+import java.util.List;
+
 public interface MemberService {
     void save(UserJoinRequest userReq);
 
@@ -28,4 +30,6 @@ public interface MemberService {
     MemberInfo getMemberInfo(Long userId);
 
     void updateMemberInfo(Long userId, MemberUpdateInfo memberUpdateInfo);
+
+    List<String> getEmails(Long ownerId);
 }

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -49,4 +49,10 @@
         </foreach>
     </insert>
 
+    <select id="getPromotionEmails" parameterType="long" resultType="string" statementType="CALLABLE">
+        { call getRestaurantIdFromOwnerID(
+                #{ownerId, mode=IN, jdbcType=BIGINT}
+        )}
+    </select>
+
 </mapper>

--- a/src/main/resources/sql/tables_create_member_info.sql
+++ b/src/main/resources/sql/tables_create_member_info.sql
@@ -101,4 +101,17 @@ CREATE TABLE bookmarks (
                            FOREIGN KEY (user_id) REFERENCES Users(user_id)
 );
 
+-- 프로모션 받기 등록한 사용자 email 찾는 방법
+delimiter ##
+create procedure getRestaurantIdFromOwnerID(in in_ownerId bigint)
+begin
+SELECT u.email
+FROM bookmarks b
+         JOIN users u ON b.user_id = u.user_id
+         JOIN restaurants r ON b.restaurant_id = r.restaurant_id
+WHERE r.owner_id = in_ownerId
+  AND b.promotion_agree = 1;
+end ##
+delimiter ;
+
 

--- a/src/main/resources/templates/promotion.html
+++ b/src/main/resources/templates/promotion.html
@@ -1,10 +1,92 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <title>$Title$</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>LunchGo Promotion</title>
+    <style>
+        /* 모바일 반응형 처리 */
+        @media only screen and (max-width: 600px) {
+            .container { width: 100% !important; }
+            .content-padding { padding: 30px 20px !important; }
+            /* 모바일에서 버튼이 꽉 차게 보이도록 설정 */
+            .button-table { width: 100% !important; max-width: 100% !important; }
+            .button-link { width: 100% !important; padding: 16px 0 !important; }
+        }
+    </style>
 </head>
-<body>
-$END$
+<body style="margin: 0; padding: 0; background-color: #F8F9FA; font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', 'Helvetica', 'Arial', sans-serif; -webkit-font-smoothing: antialiased;">
+
+<table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: #F8F9FA;">
+    <tr>
+        <td align="center" style="padding: 40px 0;">
+
+            <table class="container" border="0" cellpadding="0" cellspacing="0" width="600" style="background-color: #FFFFFF; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.05); overflow: hidden; border-collapse: collapse;">
+
+                <tr>
+                    <td height="6" style="background-color: #FF6B4A; background: linear-gradient(135deg, #FF6B4A 0%, #FFAA8D 50%, #FFC4B8 100%); line-height: 0; font-size: 0;">&nbsp;</td>
+                </tr>
+
+                <tr>
+                    <td class="content-padding" style="padding: 40px 40px 20px 40px; text-align: center;">
+                        <h1 style="margin: 0; color: #FF6B4A; font-size: 26px; font-weight: 800; letter-spacing: -0.5px;">LunchGo</h1>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td class="content-padding" style="padding: 0 40px 10px 40px; text-align: center;">
+                        <h2 style="margin: 0; color: #1E3A5F; font-size: 28px; font-weight: 700; line-height: 1.3;">
+                            프로모션
+                        </h2>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td align="center" style="padding: 20px 40px;">
+                        <div style="height: 1px; width: 60px; background-color: #E9ECEF;"></div>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td class="content-padding" style="padding: 0 40px 30px 40px; text-align: center; color: #495057; font-size: 16px; line-height: 1.8;">
+                        <div th:utext="${promotionContext}">
+                            (여기에 점주가 작성한 프로모션 내용이 들어갑니다.<br>
+                            맛있는 점심, LunchGo와 함께 더 특별하게 즐겨보세요.<br>
+                            이번 주 한정, 특정 메뉴 할인 이벤트를 진행합니다!)
+                        </div>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td class="content-padding" style="padding: 0 40px 40px 40px;">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="button-table" style="margin: 0 auto;">
+                            <tr>
+                                <td align="center" style="background-color: #FF6B4A; border-radius: 6px; box-shadow: 0 2px 4px rgba(255, 107, 74, 0.2); text-align: center;">
+                                    <a href="#" class="button-link" target="_blank" style="display: inline-block; padding: 16px 36px; font-family: sans-serif; font-size: 16px; font-weight: bold; color: #ffffff; text-decoration: none; border-radius: 6px; text-align: center; white-space: nowrap;">
+                                        지금 혜택 확인하기
+                                    </a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="background-color: #F1F3F5; padding: 30px 24px; text-align: center; border-top: 1px solid #E9ECEF;">
+                        <p style="margin: 0 0 12px 0; color: #ADB5BD; font-size: 13px; line-height: 1.5;">
+                            본 메일은 정보통신망법에 의거하여 수신동의하신 회원님께 발송되었습니다.<br/>
+                            더 이상 수신을 원치 않으시면 <a href="#" style="color: #ADB5BD; text-decoration: underline;">수신거부</a>를 클릭해주세요.
+                        </p>
+                        <p style="margin: 0; color: #ADB5BD; font-size: 12px; font-weight: 600;">
+                            Copyright © LunchGo All rights reserved.
+                        </p>
+                    </td>
+                </tr>
+
+            </table>
+        </td>
+    </tr>
+</table>
+
 </body>
 </html>


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 사업자 페이지에서 프로모션 등록 및 등록 후 메일 전송 로직 구현
- AsyncConfig를 사용하여 다량의 메일 전송에서 메일 전송을 기다리지 않고 사업자에게 메일 전송 완료 문구를 먼저 띄운 뒤 메일 전송 차례로 진행하도록 구성

## 📁 변경된 파일

- member 폴더
- email 폴더
- AsyncConfig.java
- promotion.html

## 🔗 관련 Issue(선택)

- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/188

## ✔️ 체크리스트(선택)

- Postman 테스트 통과
- 메일에서 html 양식 안깨지는거 다시 확인했음
