### PR TITLE
feat(staff): 임직원 등록 및 삭제 로직 구현

### DIFF
--- a/src/main/java/com/example/LunchGo/member/controller/MemberController.java
+++ b/src/main/java/com/example/LunchGo/member/controller/MemberController.java
@@ -1,9 +1,6 @@
 package com.example.LunchGo.member.controller;
 
-import com.example.LunchGo.member.dto.MemberInfo;
-import com.example.LunchGo.member.dto.MemberUpdateInfo;
-import com.example.LunchGo.member.dto.OwnerInfo;
-import com.example.LunchGo.member.dto.OwnerUpdateInfo;
+import com.example.LunchGo.member.dto.*;
 import com.example.LunchGo.member.entity.Owner;
 import com.example.LunchGo.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +42,22 @@ public class MemberController {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST); //아무 변경없이 수정하기 남발 금지
         }
         memberService.updateOwnerInfo(ownerId, ownerUpdateInfo);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PostMapping("/business/staff")
+    public ResponseEntity<?> addStaff(@RequestBody StaffInfo staffInfo) {
+        if(!StringUtils.hasLength(staffInfo.getEmail())) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+
+        memberService.save(staffInfo); //해당 email을 가진 user 존재하지 않으면 404
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/business/staff")
+    public ResponseEntity<?> deleteStaff(@RequestBody StaffInfo staffInfo) {
+        if(staffInfo.getStaffId() == null || staffInfo.getOwnerId() == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        //해당 점주가 관리하는 직원에 대해서만 삭제 가능하도록
+        memberService.delete(staffInfo); //delete 오류 발생시 404
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/LunchGo/member/dto/StaffInfo.java
+++ b/src/main/java/com/example/LunchGo/member/dto/StaffInfo.java
@@ -1,0 +1,16 @@
+package com.example.LunchGo.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class StaffInfo {
+    private Long ownerId; //사업자 id
+    private String email; //사용자 이메일
+    private Long staffId; //삭제시 필요한 staffId
+}

--- a/src/main/java/com/example/LunchGo/member/entity/Staff.java
+++ b/src/main/java/com/example/LunchGo/member/entity/Staff.java
@@ -1,0 +1,55 @@
+package com.example.LunchGo.member.entity;
+
+import com.example.LunchGo.member.domain.CustomRole;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "staffs")
+public class Staff {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "staff_id")
+    private Long staffId;
+
+    @Column(name = "email", unique = true, length = 100)
+    private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "created_at", nullable = false)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    private CustomRole role;
+
+    @Column(name = "owner_id", nullable = false)
+    private Long ownerId;
+
+    @Builder
+    public Staff(String email, String password, String name, CustomRole role, Long ownerId) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.role = role;
+        this.ownerId = ownerId;
+    }
+}

--- a/src/main/java/com/example/LunchGo/member/repository/StaffRepository.java
+++ b/src/main/java/com/example/LunchGo/member/repository/StaffRepository.java
@@ -1,0 +1,13 @@
+package com.example.LunchGo.member.repository;
+
+import com.example.LunchGo.member.entity.Staff;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface StaffRepository extends JpaRepository<Staff, Long> {
+
+    @Modifying
+    @Query("DELETE FROM Staff s WHERE s.staffId = :staffId AND s.ownerId = :ownerId")
+    int deleteByStaffId(Long staffId, Long ownerId);
+}

--- a/src/main/java/com/example/LunchGo/member/repository/UserRepository.java
+++ b/src/main/java/com/example/LunchGo/member/repository/UserRepository.java
@@ -35,4 +35,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE User u SET u.status = 'DORMANT' WHERE u.lastLoginAt < :current AND u.status = 'ACTIVE'")
     int updateDormantUsers(@Param("current") LocalDateTime current);
+
+    /**
+     * email로 사용자 정보 뽑아내기 (임직원 등록 시 사용)
+     * */
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/example/LunchGo/member/service/MemberService.java
+++ b/src/main/java/com/example/LunchGo/member/service/MemberService.java
@@ -3,10 +3,7 @@ package com.example.LunchGo.member.service;
 import com.example.LunchGo.account.dto.FindPwdRequest;
 import com.example.LunchGo.account.dto.OwnerJoinRequest;
 import com.example.LunchGo.account.dto.UserJoinRequest;
-import com.example.LunchGo.member.dto.MemberInfo;
-import com.example.LunchGo.member.dto.MemberUpdateInfo;
-import com.example.LunchGo.member.dto.OwnerInfo;
-import com.example.LunchGo.member.dto.OwnerUpdateInfo;
+import com.example.LunchGo.member.dto.*;
 import com.example.LunchGo.member.entity.Owner;
 import com.example.LunchGo.member.entity.User;
 
@@ -38,4 +35,8 @@ public interface MemberService {
     void updateOwnerInfo(Long ownerId, OwnerUpdateInfo ownerUpdateInfo);
 
     List<String> getEmails(Long ownerId);
+
+    void save(StaffInfo staffInfo);
+
+    void delete(StaffInfo staffInfo);
 }


### PR DESCRIPTION
## 📌 작업 내용 

- 사업자는 해당 식당의 예약 관리를 위해 임직원 이메일을 통해 등록할 수 있고, 프론트에서 삭제버튼을 누르면 해당 staffId에 해당하는 staff를 삭제할 수 있음

## 📁 변경된 파일

- member 폴더

## 🔗 관련 Issue(선택)

- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/206

## ✔️ 체크리스트(선택)

- 임직원 등록 관련 Postman 테스트 통과
<img width="1370" height="733" alt="image" src="https://github.com/user-attachments/assets/51c4ad46-5b3d-4865-866d-d77deb3a3616" />
<img width="1200" height="235" alt="image" src="https://github.com/user-attachments/assets/eab25ad7-4b46-4325-a1a5-360b1e122a01" />

- user 목록에 없는 이메일을 등록하려 한다면
<img width="1371" height="805" alt="image" src="https://github.com/user-attachments/assets/15cc6401-c215-4dc4-9a85-066373dcd5a5" />

- 임직원 삭제
<img width="1359" height="754" alt="image" src="https://github.com/user-attachments/assets/8a73dedd-03a8-4711-9e6b-aae43f91e6c3" />
<img width="1195" height="259" alt="image" src="https://github.com/user-attachments/assets/ba12b033-4d68-4c46-adf3-a60740cdba3c" />
