### PR TITLE
feat(staff): 임직원 현황 조회 및 임직원 중복 추가 방지 로직 구현

### DIFF
--- a/src/main/java/com/example/LunchGo/member/controller/MemberController.java
+++ b/src/main/java/com/example/LunchGo/member/controller/MemberController.java
@@ -9,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -49,7 +51,7 @@ public class MemberController {
     public ResponseEntity<?> addStaff(@RequestBody StaffInfo staffInfo) {
         if(!StringUtils.hasLength(staffInfo.getEmail())) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
 
-        memberService.save(staffInfo); //해당 email을 가진 user 존재하지 않으면 404
+        memberService.save(staffInfo); //해당 email을 가진 user 존재하지 않으면 404, 이미 등록한 email이면 409
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
@@ -59,5 +61,12 @@ public class MemberController {
         //해당 점주가 관리하는 직원에 대해서만 삭제 가능하도록
         memberService.delete(staffInfo); //delete 오류 발생시 404
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/business/staff/{ownerId}")
+    public ResponseEntity<?> getStaffs (@PathVariable Long ownerId) {
+        List<StaffInfo> staffs = memberService.getStaffs(ownerId);
+
+        return new ResponseEntity<>(staffs, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/LunchGo/member/dto/StaffInfo.java
+++ b/src/main/java/com/example/LunchGo/member/dto/StaffInfo.java
@@ -13,4 +13,5 @@ public class StaffInfo {
     private Long ownerId; //사업자 id
     private String email; //사용자 이메일
     private Long staffId; //삭제시 필요한 staffId
+    private String name;
 }

--- a/src/main/java/com/example/LunchGo/member/repository/StaffRepository.java
+++ b/src/main/java/com/example/LunchGo/member/repository/StaffRepository.java
@@ -5,9 +5,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface StaffRepository extends JpaRepository<Staff, Long> {
 
     @Modifying
     @Query("DELETE FROM Staff s WHERE s.staffId = :staffId AND s.ownerId = :ownerId")
     int deleteByStaffId(Long staffId, Long ownerId);
+
+    boolean existsByEmail(String email);
+
+    List<Staff> searchByOwnerId(Long ownerId);
 }

--- a/src/main/java/com/example/LunchGo/member/service/MemberService.java
+++ b/src/main/java/com/example/LunchGo/member/service/MemberService.java
@@ -39,4 +39,6 @@ public interface MemberService {
     void save(StaffInfo staffInfo);
 
     void delete(StaffInfo staffInfo);
+
+    List<StaffInfo> getStaffs(Long ownerId);
 }


### PR DESCRIPTION
## 📌 작업 내용 

- 사업자의 임직원 현황 조회 백엔드 로직 구현
- 임직원 등록 시, 중복 방지를 위한 로직 추가

## 📁 변경된 파일

- member 폴더

## 🔗 관련 Issue(선택)

- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/208

## ✔️ 체크리스트(선택)

- 현황 조회 관련 Postman test 통과
<img width="1375" height="985" alt="image" src="https://github.com/user-attachments/assets/ba218573-0458-4ac4-90f0-7258323a8c02" />
