### PR TITLE
feat(bookmark): 즐겨찾기 추가 및 삭제 백엔드 로직 구현

### DIFF
--- a/src/main/java/com/example/LunchGo/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/example/LunchGo/bookmark/controller/BookmarkController.java
@@ -1,0 +1,35 @@
+package com.example.LunchGo.bookmark.controller;
+
+import com.example.LunchGo.bookmark.dto.BookmarkInfo;
+import com.example.LunchGo.bookmark.service.BookmarkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class BookmarkController {
+    private final BookmarkService bookmarkService;
+
+    @PostMapping("/bookmark")
+    public ResponseEntity<?> addBookmark(@RequestBody BookmarkInfo bookmarkInfo) {
+        if(bookmarkInfo.getUserId() == null || bookmarkInfo.getRestaurantId() == null) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        bookmarkService.save(bookmarkInfo); //이미 등록된 식당이면 409
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/bookmark")
+    public ResponseEntity<?> deleteBookmark(@RequestBody BookmarkInfo bookmarkInfo) {
+        if(bookmarkInfo.getUserId() == null || bookmarkInfo.getBookmarkId() == null) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        bookmarkService.delete(bookmarkInfo); //등록되어 있지 않은 식당이면 404
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/LunchGo/bookmark/dto/BookmarkInfo.java
+++ b/src/main/java/com/example/LunchGo/bookmark/dto/BookmarkInfo.java
@@ -1,0 +1,16 @@
+package com.example.LunchGo.bookmark.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookmarkInfo {
+    private Long bookmarkId; //삭제 시 필요
+    private Long restaurantId; //등록시 필요
+    private Long userId; //해당 유저 정보 필수
+}

--- a/src/main/java/com/example/LunchGo/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/example/LunchGo/bookmark/entity/Bookmark.java
@@ -1,0 +1,35 @@
+package com.example.LunchGo.bookmark.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "bookmarks")
+public class Bookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bookmark_id")
+    private Long bookmarkId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "restaurant_id", nullable = false)
+    private Long restaurantId;
+
+    @Column(name = "promotion_agree")
+    private Boolean promotionAgree;
+
+    @Builder
+    public Bookmark(Long userId, Long restaurantId, Boolean promotionAgree) {
+        this.userId = userId;
+        this.restaurantId = restaurantId;
+        this.promotionAgree = promotionAgree;
+    }
+}

--- a/src/main/java/com/example/LunchGo/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/example/LunchGo/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,22 @@
+package com.example.LunchGo.bookmark.repository;
+
+import com.example.LunchGo.bookmark.entity.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+    /**
+     * 사용자 즐겨찾기 삭제
+     * */
+    @Modifying
+    @Query("DELETE FROM Bookmark b WHERE b.bookmarkId = :bookmarkId AND b.userId = :userId")
+    int deleteByBookmarkId(Long bookmarkId, Long userId);
+
+    /**
+     * 즐겨찾기 여부 확인
+     * */
+    boolean existsByBookmarkId(Long bookmarkId);
+
+    boolean existsByUserIdAndRestaurantId(Long userId, Long restaurantId);
+}

--- a/src/main/java/com/example/LunchGo/bookmark/service/BaseBookmarkService.java
+++ b/src/main/java/com/example/LunchGo/bookmark/service/BaseBookmarkService.java
@@ -1,0 +1,42 @@
+package com.example.LunchGo.bookmark.service;
+
+import com.example.LunchGo.bookmark.dto.BookmarkInfo;
+import com.example.LunchGo.bookmark.entity.Bookmark;
+import com.example.LunchGo.bookmark.repository.BookmarkRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class BaseBookmarkService implements BookmarkService {
+    private final BookmarkRepository bookmarkRepository;
+
+    @Override
+    public void save(BookmarkInfo bookmarkInfo) {
+        //존재하는 즐겨찾기인지 확인
+        if(bookmarkRepository.existsByUserIdAndRestaurantId(bookmarkInfo.getUserId(), bookmarkInfo.getRestaurantId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 즐겨찾기에 등록되어 있습니다.");
+        }
+
+        bookmarkRepository.save(Bookmark.builder()
+                .userId(bookmarkInfo.getUserId()) //해당 사용자
+                .restaurantId(bookmarkInfo.getRestaurantId()) //식당Id를 즐겨찾기에 등록
+                        .promotionAgree(false) //기본값 false
+                .build());
+    }
+
+    @Override
+    @Transactional
+    public void delete(BookmarkInfo bookmarkInfo) {
+        if(!bookmarkRepository.existsByBookmarkId(bookmarkInfo.getBookmarkId())) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "즐겨찾기에 등록되어있지 않습니다.");
+        }
+
+        bookmarkRepository.deleteByBookmarkId(bookmarkInfo.getBookmarkId(), bookmarkInfo.getUserId());
+    }
+}

--- a/src/main/java/com/example/LunchGo/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/example/LunchGo/bookmark/service/BookmarkService.java
@@ -1,0 +1,9 @@
+package com.example.LunchGo.bookmark.service;
+
+import com.example.LunchGo.bookmark.dto.BookmarkInfo;
+
+public interface BookmarkService {
+    void save(BookmarkInfo bookmarkInfo);
+
+    void delete(BookmarkInfo bookmarkInfo);
+}


### PR DESCRIPTION
## 📌 작업 내용 

- 사용자 즐겨찾기 추가 및 삭제 백엔드 로직 구현
- 사용자는 빈 별을 눌러 채워지는 경우, 즐겨찾기 추가할 수 있음
- 채운 별을 다시 빈 별로 눌러 바꾸는 경우, 즐겨찾기에서 삭제할 수 있음

## 📁 변경된 파일

- bookmark 폴더

## 🔗 관련 Issue(선택)

- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/211

## ✔️ 체크리스트(선택)

- 즐겨찾기 추가 Postman 테스트 통과
<img width="1373" height="741" alt="image" src="https://github.com/user-attachments/assets/778c2da7-ee93-4cd5-89e4-65e733f5e312" />
<img width="1161" height="409" alt="image" src="https://github.com/user-attachments/assets/168a0a6e-7f93-461f-bede-e3f945b33ab3" />

- 즐겨찾기 삭제 Postman 테스트 통과
<img width="1378" height="642" alt="image" src="https://github.com/user-attachments/assets/a7986ad8-f86a-403e-a3f1-d3461aa92e41" />
<img width="1179" height="355" alt="image" src="https://github.com/user-attachments/assets/0a32a349-02fa-40aa-9b42-c3bc693105d4" />


- 이후 프론트에 추가 및 삭제에 관한 api 요청 연결 및 테스트 예정
