### PR TITLE
feat(bookmark): 즐겨찾기 프론트 구분 및 api 연동

### DIFF
--- a/frontend/src/components/ui/FavoriteHeart.vue
+++ b/frontend/src/components/ui/FavoriteHeart.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { Heart } from 'lucide-vue-next';
+import axios from 'axios'; 
+import { data } from 'autoprefixer';
+
+//userId를 pinia에서 가져와야함
+const userId = ref('');
+
+const props = defineProps<{
+  restaurantId: number;
+  initialFavorite?: boolean; // 초기 즐겨찾기 상태
+}>();
+
+// 부모에게 상태 변경을 알리기 위한 이벤트 정의
+const emit = defineEmits<{
+  (e: 'update:favorite', status: boolean): void; // 상태가 바뀔 때
+  (e: 'remove'): void; // 해제 시 목록에서 제거
+}>();
+
+// 내부 상태 관리
+const isActive = ref(props.initialFavorite || false);
+
+// props가 외부에서 변할 경우 동기화
+watch(() => props.initialFavorite, (newVal) => {
+  isActive.value = newVal || false;
+});
+
+const toggleFavorite = async () => {
+  const previousState = isActive.value;
+
+  // 1. 채워진 상태 -> 빈 상태
+  if (isActive.value) {
+    if (!confirm('즐겨찾기를 해제하시겠습니까?')) return;
+    
+    // UI 낙관적 업데이트 (API 응답 전 미리 변경)
+    isActive.value = false;
+    
+    try {
+      await axios.delete(`/api/bookmark`,{ 
+      data: { userId: userId.value, restaurantId: props.restaurantId }
+    });
+      
+      emit('update:favorite', false);
+      emit('remove'); // 부모에게 삭제 알림 (목록에서 제거)
+      
+    } catch (error) {
+      isActive.value = previousState; // 실패 시 롤백
+      const status = error.response.status;
+
+      switch(status){
+        case 400:
+            alert("[400 Bad Request] 잘못된 요청입니다 입력값을 확인해주세요.");
+            break;
+        case 404:
+            alert("[404 Not Found] 이미 삭제되었거나 즐겨찾기에 없는 맛집입니다.");
+            isActive.value = false;
+            break;
+        default:
+            alert(`오류가 발생했습니다. (Code: ${status})`);
+      }
+    }
+  } 
+  // 2. 빈 상태 -> 채워진 상태 (등록)
+  else {
+    isActive.value = true;
+    
+    try {
+      await axios.post('/api/bookmark', {
+        userId: userId.value, restaurantId: props.restaurantId 
+      });
+      
+      emit('update:favorite', true);
+      
+    } catch (error) {
+      isActive.value = previousState; //롤백
+      
+      const status = error.response.status;
+
+      switch(status){
+        case 400:
+            alert("[400 Bad Request] 잘못된 요청입니다 입력값을 확인해주세요.");
+            break;
+        case 409:
+            alert("[409 Conflict] 이미 즐겨찾기에 추가되어 있습니다.");
+            isActive.value = true;
+            break;
+        default:
+            alert(`오류가 발생했습니다. (Code: ${status})`);
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <button 
+    @click.prevent="toggleFavorite"
+    class="w-6 h-6 flex items-center justify-center hover:bg-gray-50 rounded-full transition-colors focus:outline-none"
+    :title="isActive ? '즐겨찾기 해제' : '즐겨찾기 등록'"
+  >
+    <Heart 
+      class="w-4 h-4 transition-all duration-200" 
+      :class="isActive 
+        ? 'fill-[#ff6b4a] text-[#ff6b4a]' 
+        : 'fill-none text-gray-300'"
+    />
+  </button>
+</template>

--- a/frontend/src/components/ui/UserFavorites.vue
+++ b/frontend/src/components/ui/UserFavorites.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { RouterLink } from 'vue-router';
-import { Heart, Star, Bell } from 'lucide-vue-next';
+import { Star, Bell } from 'lucide-vue-next';
+import FavoriteHeart from '@/components/ui/FavoriteHeart.vue';
 // import axios from 'axios'; // 실제 API 연동 시 주석 해제
 
 // 타입 정의
@@ -15,6 +16,7 @@ interface Restaurant {
   price: string;
   badgeColor: string;
   hasPromotion: boolean; // 프로모션 알림 수신 여부
+  isFavorite: boolean;
 }
 
 //api 호출 시 필요한 정보(변수명과 매핑)
@@ -57,6 +59,7 @@ const fetchFavorites = async () => {
         price: '18,000원 · 4인 ~ 12인',
         badgeColor: 'bg-emerald-500',
         hasPromotion: true, // 이미 알림 받는 중
+        isFavorite:true,
       },
       {
         id: 2,
@@ -68,6 +71,7 @@ const fetchFavorites = async () => {
         price: '15,000원 · 4인 ~ 10인',
         badgeColor: 'bg-emerald-600',
         hasPromotion: false, // 알림 안 받는 중
+        isFavorite: true,
       },
       {
         id: 3,
@@ -79,6 +83,7 @@ const fetchFavorites = async () => {
         price: '22,000원 · 4인 ~ 8인',
         badgeColor: 'bg-emerald-500',
         hasPromotion: false,
+        isFavorite: true,
       },
     ];
   } catch (error) {
@@ -93,12 +98,10 @@ onMounted(() => {
   fetchFavorites();
 });
 
-// 찜 해제 핸들러
-const toggleFavorite = async (id: number) => {
-  if (confirm('즐겨찾기에서 삭제하시겠습니까?')) {
-    favorites.value = favorites.value.filter((item) => item.id !== id);
-    // API 삭제 로직 추가 가능
-  }
+
+//찜 해제
+const handleRemoveFromList = (id:number) => {
+  favorites.value = favorites.value.filter(item => item.id !== id);
 };
 
 // [프로모션 토글 핸들러]
@@ -161,12 +164,13 @@ const handlePromotionToggle = async (restaurant: Restaurant) => {
               <div class="flex-1 min-w-0 flex flex-col justify-center">
                 <div class="flex items-start justify-between mb-1">
                   <h4 class="font-bold text-[#1e3a5f] text-sm truncate pr-2">{{ restaurant.name }}</h4>
-                  <button 
-                    @click.prevent="toggleFavorite(restaurant.id)"
-                    class="w-6 h-6 flex items-center justify-center hover:bg-gray-50 rounded-full -mt-1 -mr-1 transition-colors"
-                  >
-                    <Heart class="w-4 h-4 fill-[#ff6b4a] text-[#ff6b4a]" />
-                  </button>
+                  <div class="-mt-1 -mr-1">
+                    <FavoriteHeart
+                      :restaurant-id="restaurant.id"
+                      :initial-favorite="restaurant.isFavorite"
+                      @remove="handleRemoveFromList(restaurant.id)" 
+                    />
+                  </div>
                 </div>
                 
                 <div class="flex items-center gap-1 mb-1.5">

--- a/src/main/java/com/example/LunchGo/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/example/LunchGo/bookmark/controller/BookmarkController.java
@@ -25,7 +25,7 @@ public class BookmarkController {
 
     @DeleteMapping("/bookmark")
     public ResponseEntity<?> deleteBookmark(@RequestBody BookmarkInfo bookmarkInfo) {
-        if(bookmarkInfo.getUserId() == null || bookmarkInfo.getBookmarkId() == null) {
+        if(bookmarkInfo.getUserId() == null || bookmarkInfo.getRestaurantId() == null) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
 

--- a/src/main/java/com/example/LunchGo/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/example/LunchGo/bookmark/repository/BookmarkRepository.java
@@ -10,13 +10,11 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
      * 사용자 즐겨찾기 삭제
      * */
     @Modifying
-    @Query("DELETE FROM Bookmark b WHERE b.bookmarkId = :bookmarkId AND b.userId = :userId")
-    int deleteByBookmarkId(Long bookmarkId, Long userId);
+    @Query("DELETE FROM Bookmark b WHERE b.restaurantId = :restaurantId AND b.userId = :userId")
+    int deleteByRestaurantIdAndUserId(Long restaurantId, Long userId);
 
     /**
      * 즐겨찾기 여부 확인
      * */
-    boolean existsByBookmarkId(Long bookmarkId);
-
     boolean existsByUserIdAndRestaurantId(Long userId, Long restaurantId);
 }

--- a/src/main/java/com/example/LunchGo/bookmark/service/BaseBookmarkService.java
+++ b/src/main/java/com/example/LunchGo/bookmark/service/BaseBookmarkService.java
@@ -33,10 +33,10 @@ public class BaseBookmarkService implements BookmarkService {
     @Override
     @Transactional
     public void delete(BookmarkInfo bookmarkInfo) {
-        if(!bookmarkRepository.existsByBookmarkId(bookmarkInfo.getBookmarkId())) {
+        if(!bookmarkRepository.existsByUserIdAndRestaurantId(bookmarkInfo.getUserId(), bookmarkInfo.getRestaurantId())) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "즐겨찾기에 등록되어있지 않습니다.");
         }
 
-        bookmarkRepository.deleteByBookmarkId(bookmarkInfo.getBookmarkId(), bookmarkInfo.getUserId());
+        bookmarkRepository.deleteByRestaurantIdAndUserId(bookmarkInfo.getRestaurantId(), bookmarkInfo.getUserId());
     }
 }


### PR DESCRIPTION
## 📌 작업 내용 

- 즐겨찾기 하트 모양 프론트 구분 및 api 연동
- 즐겨찾기 삭제 시, bookmarkId보단 restaurantId와 userId 조건을 걸어 delete하는게 유연성이 있어 교체

## 📁 변경된 파일

- frontend/src/components/ui/FavortieHeart.vue
- frontend/src/components/ui/UserFavorties.vue
- bookmark 폴더

## 🔗 관련 Issue(선택)

- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/213

## ✔️ 체크리스트(선택)

- 현재 userId를 pinia에서 받아오도록 설정하지 않아 테스트는 추후 로그인 로그아웃 구현 시 한번에 PR 올리도록 하겠습니다
- 즐겨찾기 하트 가져가시려면 FavoriteHeart.vue를 가져가시면 됩니다
