### PR TITLE
feat(restaurant): 식당정보 조회/등록/수정 기능 중 식당메뉴 조회/등록/수정 기능 추가 + 프론트엔드 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 
 	//coolSMS 의존성 주입
 	implementation 'net.nurigo:sdk:4.3.0'
+	// ModelMapper
+	implementation 'org.modelmapper:modelmapper:3.2.0'
 }
 
 tasks.named('test') {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -289,7 +289,6 @@ router.beforeEach((to, from) => {
   // Pinia 스토어는 Vue 앱이 실행된 후에 사용 가능하므로, 가드 내에서 직접 호출합니다.
   const store = useRestaurantStore();
 
-  // 식당 정보 등록/수정 워크플로우에 해당하는 라우트 이름 목록
   const workflowRoutes = [
     'business-restaurant-info-add',
     'business-restaurant-info-edit',
@@ -300,9 +299,19 @@ router.beforeEach((to, from) => {
   const isFromWorkflow = workflowRoutes.includes(from.name);
   const isToWorkflow = workflowRoutes.includes(to.name);
 
-  // 워크플로우를 벗어나는 경우에만 store를 초기화합니다.
+  // Case 1: 워크플로우를 완전히 벗어나는 경우, 데이터를 초기화합니다.
   if (isFromWorkflow && !isToWorkflow) {
     store.clearRestaurant();
+    return;
+  }
+
+  // Case 2: '식당 등록' 페이지로 진입하는 경우
+  if (to.name === 'business-restaurant-info-add') {
+    // 스토어가 비어있거나, '수정' 중이던 데이터(ID가 있는 데이터)가 남아있는 경우,
+    // 새로운 '등록'을 위해 상태를 깨끗하게 초기화합니다.
+    if (!store.restaurantInfo || store.restaurantInfo.restaurantId) {
+      store.initializeNewRestaurant();
+    }
   }
 });
 

--- a/frontend/src/stores/restaurant.js
+++ b/frontend/src/stores/restaurant.js
@@ -2,12 +2,40 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import axios from 'axios'; // axios 임포트
 
+// 새 식당 정보의 기본 구조
+const defaultRestaurant = () => ({
+  name: '',
+  phone: '',
+  roadAddress: '',
+  detailAddress: '',
+  description: '',
+  avgMainPrice: 0,
+  reservationLimit: '',
+  holidayAvailable: false,
+  preorderAvailable: false,
+  openTime: '',
+  closeTime: '',
+  openDate: '',
+  images: [],
+  regularHolidays: [],
+  tags: [],
+});
+
 export const useRestaurantStore = defineStore('restaurant', () => {
   // State
   const restaurantInfo = ref(null); // 현재 편집 중인 식당 정보 전체
   const menus = ref([]);
 
   // Actions
+
+  /**
+   * 새 식당 등록을 위해 스토어를 초기화합니다.
+   */
+  function initializeNewRestaurant() {
+    restaurantInfo.value = defaultRestaurant();
+    menus.value = [];
+  }
+
   /**
    * 수정 모드에서 식당 데이터를 로드합니다.
    * 스토어에 이미 같은 식당 데이터가 로드되어 있다면 아무것도 하지 않습니다.
@@ -90,6 +118,7 @@ export const useRestaurantStore = defineStore('restaurant', () => {
   return { 
     restaurantInfo,
     menus, 
+    initializeNewRestaurant,
     loadRestaurant,
     fetchRestaurantDetail, // 새로운 액션 추가
     clearRestaurant,

--- a/frontend/src/views/business/restaurant-info/RestaurantInfoPage.vue
+++ b/frontend/src/views/business/restaurant-info/RestaurantInfoPage.vue
@@ -229,7 +229,7 @@ onMounted(async () => { // async 추가
                 </label>
                 <div class="flex flex-wrap gap-3">
                   <button
-                    v-for="day in ['월', '화', '수', '목', '금', '토', '일']"
+                    v-for="day in ['일', '월', '화', '수', '목', '금', '토']"
                     :key="day"
                     :class="`px-4 py-2 rounded-lg border transition-colors ${
                       closedDaysAsStrings.includes(day)

--- a/frontend/src/views/business/restaurant-info/menu/MenuEditPage.vue
+++ b/frontend/src/views/business/restaurant-info/menu/MenuEditPage.vue
@@ -96,15 +96,15 @@ onMounted(async () => {
 
   if (isEditMode.value) {
     // 2. (수정 모드일 경우) 기존 메뉴 정보 가져오기
-    // API: GET /api/menus/{menuId}
     const menuId = route.params.id;
     const existingMenu = store.getMenuById(menuId);
     if (existingMenu) {
       // 스토어에서 찾은 메뉴로 데이터 채우기
       menuData.id = existingMenu.id;
       menuData.name = existingMenu.name;
-      // 'type'을 'category'로 매핑
-      menuData.category = menuTypes.value.find(mt => mt.text === existingMenu.type)?.value || '';
+
+      // 'category' 객체에서 'code'를 사용해 v-model과 바인딩
+      menuData.category = existingMenu.category?.code || '';
       menuData.price = existingMenu.price;
       menuData.tags = existingMenu.tags || []; // 태그가 없을 수 있으므로 기본값 설정
       menuData.imageUrl = existingMenu.imageUrl || ''; // 이미지 URL이 없을 수 있음
@@ -128,11 +128,12 @@ const saveMenu = () => {
   }
 
   let isValid = true;
-  // menuData.imageUrl이 이미 존재하면 이미지 파일 필수 아님 (수정 모드)
-  if (!imageFile.value && !menuData.imageUrl) {
-    validationErrors.image = '메뉴 사진을 등록해주세요.';
-    isValid = false;
-  }
+  // // 메뉴 이미지 유효성 검사 (백엔드 로직 미구현으로 임시 주석 처리)
+  // // menuData.imageUrl이 이미 존재하면 이미지 파일 필수 아님 (수정 모드)
+  // if (!imageFile.value && !menuData.imageUrl) {
+  //   validationErrors.image = '메뉴 사진을 등록해주세요.';
+  //   isValid = false;
+  // }
   if (!menuData.name.trim()) {
     validationErrors.name = '메뉴 이름을 입력해주세요.';
     isValid = false;
@@ -155,13 +156,15 @@ const saveMenu = () => {
     return;
   }
 
-  const menuTypeKor =
-    menuTypes.value.find((mt) => mt.value === menuData.category)?.text || '';
+  const selectedCategoryObject =
+    menuTypes.value.find((mt) => mt.value === menuData.category) || {};
   const menuToSave = {
     id: menuData.id,
     name: menuData.name,
-    category: menuData.category, // DB enum 값
-    type: menuTypeKor, // RestaurantInfoEditPage에서 보여주기 위한 한글 타입
+    category: {
+      code: selectedCategoryObject.value,
+      value: selectedCategoryObject.text,
+    },
     price: menuData.price,
     tags: menuData.tags,
     imageUrl: menuData.imageUrl,

--- a/frontend/src/views/business/restaurant-info/menu/MenuEditPage.vue
+++ b/frontend/src/views/business/restaurant-info/menu/MenuEditPage.vue
@@ -27,6 +27,7 @@ const menuData = reactive({
   name: '',
   category: '',
   price: 0,
+  description: '', // 메뉴 설명 추가
   tags: [], // 재료 태그는 메뉴 객체에 포함하여 관리
   imageUrl: '', // 이미지 URL도 메뉴 객체에 포함
 });
@@ -106,6 +107,7 @@ onMounted(async () => {
       // 'category' 객체에서 'code'를 사용해 v-model과 바인딩
       menuData.category = existingMenu.category?.code || '';
       menuData.price = existingMenu.price;
+      menuData.description = existingMenu.description || ''; // description 추가
       menuData.tags = existingMenu.tags || []; // 태그가 없을 수 있으므로 기본값 설정
       menuData.imageUrl = existingMenu.imageUrl || ''; // 이미지 URL이 없을 수 있음
       imageUrl.value = menuData.imageUrl;
@@ -118,6 +120,7 @@ const validationErrors = reactive({
   name: '',
   category: '',
   price: '',
+  description: '', // 메뉴 설명 유효성 검사 에러 필드 추가
 });
 
 // 7. 저장 함수
@@ -166,6 +169,7 @@ const saveMenu = () => {
       value: selectedCategoryObject.text,
     },
     price: menuData.price,
+    description: menuData.description, // 메뉴 설명 추가
     tags: menuData.tags,
     imageUrl: menuData.imageUrl,
   };
@@ -207,6 +211,12 @@ watch(
   () => menuData.imageUrl,
   (newUrl) => {
     if (newUrl) validationErrors.image = '';
+  }
+);
+watch(
+  () => menuData.description, // description 필드에 대한 watch 추가
+  (newValue) => {
+    if (newValue.trim()) validationErrors.description = '';
   }
 );
 </script>
@@ -345,6 +355,25 @@ watch(
                   class="text-red-500 text-sm mt-1"
                 >
                   {{ validationErrors.price }}
+                </p>
+              </div>
+
+              <!-- Menu Description -->
+              <div>
+                <label class="block text-sm font-semibold text-[#1e3a5f] mb-2"
+                  >메뉴 설명</label
+                >
+                <textarea
+                  placeholder="메뉴 설명을 입력하세요"
+                  v-model="menuData.description"
+                  rows="4"
+                  class="w-full px-4 py-3 border border-[#dee2e6] rounded-lg focus:outline-none focus:ring-2 focus:ring-[#FF6B4A] resize-none"
+                ></textarea>
+                <p
+                  v-if="validationErrors.description"
+                  class="text-red-500 text-sm mt-1"
+                >
+                  {{ validationErrors.description }}
                 </p>
               </div>
 

--- a/src/main/java/com/example/LunchGo/common/config/ModelMapperConfig.java
+++ b/src/main/java/com/example/LunchGo/common/config/ModelMapperConfig.java
@@ -1,0 +1,21 @@
+package com.example.LunchGo.common.config;
+
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModelMapperConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+        ModelMapper modelMapper = new ModelMapper();
+        modelMapper.getConfiguration()
+                .setFieldMatchingEnabled(true)
+                .setFieldAccessLevel(org.modelmapper.config.Configuration.AccessLevel.PRIVATE)
+                .setMatchingStrategy(MatchingStrategies.STRICT)
+                .setSkipNullEnabled(true);
+        return modelMapper;
+    }
+}

--- a/src/main/java/com/example/LunchGo/restaurant/controller/BusinessRestaurantController.java
+++ b/src/main/java/com/example/LunchGo/restaurant/controller/BusinessRestaurantController.java
@@ -59,7 +59,8 @@ public class BusinessRestaurantController {
     @PutMapping("/{id}")
     public ResponseEntity<RestaurantDetailResponse> updateRestaurant(
             @PathVariable("id") Long id,
-            @RequestBody RestaurantUpdateRequest request) {
+            @RequestBody RestaurantUpdateRequest request
+    ) {
         RestaurantDetailResponse updatedRestaurant = businessRestaurantService.updateRestaurant(id, request);
 
         return ResponseEntity.ok(updatedRestaurant);

--- a/src/main/java/com/example/LunchGo/restaurant/controller/BusinessRestaurantController.java
+++ b/src/main/java/com/example/LunchGo/restaurant/controller/BusinessRestaurantController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 
 @RestController
-@RequestMapping("/api/business/restaurants")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class BusinessRestaurantController {
 
@@ -24,7 +24,7 @@ public class BusinessRestaurantController {
      * @param id 식당 ID
      * @return RestaurantDetailResponse DTO를 포함하는 ResponseEntity
      */
-    @GetMapping("/{id}")
+    @GetMapping("/business/restaurants/{id}")
     public ResponseEntity<RestaurantDetailResponse> getRestaurantDetail(
             @PathVariable("id") Long id
     ) {
@@ -39,7 +39,7 @@ public class BusinessRestaurantController {
      * @param request RestaurantCreateRequest DTO
      * @return 생성된 식당 ID를 포함하는 ResponseEntity
      */
-    @PostMapping
+    @PostMapping("/business/restaurants")
     public ResponseEntity<Long> createRestaurant(
             @RequestBody RestaurantCreateRequest request
     ) {
@@ -56,7 +56,7 @@ public class BusinessRestaurantController {
      * @param request RestaurantUpdateRequest DTO
      * @return 수정된 RestaurantDetailResponse DTO를 포함하는 ResponseEntity
      */
-    @PutMapping("/{id}")
+    @PutMapping("/business/restaurants/{id}")
     public ResponseEntity<RestaurantDetailResponse> updateRestaurant(
             @PathVariable("id") Long id,
             @RequestBody RestaurantUpdateRequest request

--- a/src/main/java/com/example/LunchGo/restaurant/controller/MenuController.java
+++ b/src/main/java/com/example/LunchGo/restaurant/controller/MenuController.java
@@ -1,0 +1,32 @@
+package com.example.LunchGo.restaurant.controller;
+
+import com.example.LunchGo.restaurant.dto.MenuDTO;
+import com.example.LunchGo.restaurant.service.MenuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MenuController {
+
+    private final MenuService menuService;
+
+    /**
+     * 특정 식당의 모든 메뉴 리스트를 조회합니다.
+     *
+     * @param restaurantId 식당 ID
+     * @return 메뉴 DTO 리스트를 포함하는 ResponseEntity
+     */
+    @GetMapping("/restaurants/{restaurantId}/menus")
+    public ResponseEntity<List<MenuDTO>> getMenus(@PathVariable Long restaurantId) {
+        List<MenuDTO> menus = menuService.getMenusByRestaurant(restaurantId);
+        return ResponseEntity.ok(menus);
+    }
+}

--- a/src/main/java/com/example/LunchGo/restaurant/domain/MenuCategory.java
+++ b/src/main/java/com/example/LunchGo/restaurant/domain/MenuCategory.java
@@ -1,7 +1,39 @@
 package com.example.LunchGo.restaurant.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum MenuCategory {
-    MAIN,
-    SUB,
-    OTHER
+
+    MAIN("주메뉴"),
+    SUB("서브메뉴"),
+    OTHER("기타(디저트, 음료)");
+
+    private final String displayName;
+
+    MenuCategory(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @JsonProperty("value")
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @JsonProperty("code")
+    public String getCode() {
+        return name();
+    }
+
+    //
+    @JsonCreator
+    public static MenuCategory fromCode(Map<String, String> obj) {
+        if (obj != null && obj.containsKey("code")) {
+            return MenuCategory.valueOf(obj.get("code"));
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/example/LunchGo/restaurant/dto/ImageDTO.java
+++ b/src/main/java/com/example/LunchGo/restaurant/dto/ImageDTO.java
@@ -7,6 +7,6 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ImageDto {
+public class ImageDTO {
     private String imageUrl;
 }

--- a/src/main/java/com/example/LunchGo/restaurant/dto/MenuDTO.java
+++ b/src/main/java/com/example/LunchGo/restaurant/dto/MenuDTO.java
@@ -1,0 +1,28 @@
+package com.example.LunchGo.restaurant.dto;
+
+import com.example.LunchGo.restaurant.domain.MenuCategory;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List; // List 임포트 추가
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuDTO {
+
+    @JsonProperty("id")
+    private Long menuId;
+    private String name;
+    private MenuCategory category;
+    private Integer price;
+
+    private String description;
+    private String imageUrl;
+
+    private List<MenuTagDTO> tags; // 메뉴 태그 리스트 필드 추가
+}

--- a/src/main/java/com/example/LunchGo/restaurant/dto/MenuTagDTO.java
+++ b/src/main/java/com/example/LunchGo/restaurant/dto/MenuTagDTO.java
@@ -8,7 +8,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class RestaurantTagDTO {
+public class MenuTagDTO {
     private Long tagId;
     private String content;
     private TagCategory category;

--- a/src/main/java/com/example/LunchGo/restaurant/dto/MenuTagMappingDTO.java
+++ b/src/main/java/com/example/LunchGo/restaurant/dto/MenuTagMappingDTO.java
@@ -1,0 +1,16 @@
+package com.example.LunchGo.restaurant.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuTagMappingDTO {
+    // N+1 문제 해결용 DTO
+    private Long menuId;
+    private Long tagId;
+}

--- a/src/main/java/com/example/LunchGo/restaurant/dto/RegularHolidayDto.java
+++ b/src/main/java/com/example/LunchGo/restaurant/dto/RegularHolidayDto.java
@@ -7,6 +7,6 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class RegularHolidayDto {
+public class RegularHolidayDTO {
     private Integer dayOfWeek;
 }

--- a/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantCreateRequest.java
+++ b/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantCreateRequest.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Getter
@@ -21,12 +22,17 @@ public class RestaurantCreateRequest {
     private String detailAddress;
     private String description;
     private Integer reservationLimit;
+
     private boolean holidayAvailable;
     private boolean preorderAvailable;
-    private String openTime; // "HH:mm"
-    private String closeTime; // "HH:mm"
+
+    private LocalTime openTime;
+    private LocalTime closeTime;
     private LocalDate openDate;
+
     private List<String> imageUrls;
-    private List<Integer> regularHolidayNumbers;
+    private List<Integer> regularHolidayNumbers;    // 1이면 일요일, 7이면 토요일
     private List<Long> selectedTagIds;
+    private List<MenuDTO> menus;
+    private Integer avgMainPrice;
 }

--- a/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantDetailResponse.java
+++ b/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantDetailResponse.java
@@ -31,8 +31,9 @@ public class RestaurantDetailResponse {
     private String closeTime; // "HH:mm" format
     private LocalDate openDate;
 
-    private List<ImageDto> images;
-    private List<RestaurantTagDto> tags;
-    private List<RegularHolidayDto> regularHolidays;
+    private List<ImageDTO> images;
+    private List<RestaurantTagDTO> tags;
+    private List<RegularHolidayDTO> regularHolidays;
+    private List<MenuDTO> menus;
 
 }

--- a/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantUpdateRequest.java
+++ b/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantUpdateRequest.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Getter
@@ -21,11 +22,16 @@ public class RestaurantUpdateRequest {
     private String detailAddress;
     private String description;
     private Integer reservationLimit;
+
     private boolean holidayAvailable;
     private boolean preorderAvailable;
-    private String openTime; // "HH:mm"
-    private String closeTime; // "HH:mm"
+
+    private LocalTime openTime;
+    private LocalTime closeTime;
     private LocalDate openDate;
+
     private List<Integer> regularHolidayNumbers;
     private List<Long> selectedTagIds;
+    private List<MenuDTO> menus;
+    private Integer avgMainPrice;
 }

--- a/src/main/java/com/example/LunchGo/restaurant/service/BusinessRestaurantService.java
+++ b/src/main/java/com/example/LunchGo/restaurant/service/BusinessRestaurantService.java
@@ -1,28 +1,22 @@
 package com.example.LunchGo.restaurant.service;
 
+import com.example.LunchGo.restaurant.dto.MenuDTO;
 import com.example.LunchGo.restaurant.domain.RestaurantStatus;
-import com.example.LunchGo.restaurant.dto.ImageDto;
-import com.example.LunchGo.restaurant.dto.RegularHolidayDto;
+import com.example.LunchGo.restaurant.dto.ImageDTO;
+import com.example.LunchGo.restaurant.dto.RegularHolidayDTO;
 import com.example.LunchGo.restaurant.dto.RestaurantDetailResponse;
 import com.example.LunchGo.restaurant.dto.RestaurantCreateRequest; // Import added
-import com.example.LunchGo.restaurant.dto.RestaurantTagDto;
-import com.example.LunchGo.restaurant.entity.RegularHoliday;
+import com.example.LunchGo.restaurant.dto.RestaurantTagDTO;
 import com.example.LunchGo.restaurant.entity.Restaurant;
-import com.example.LunchGo.restaurant.repository.RegularHolidayRepository;
 import com.example.LunchGo.restaurant.repository.RestaurantRepository;
 import com.example.LunchGo.restaurant.dto.RestaurantUpdateRequest;
-import com.example.LunchGo.tag.entity.SearchTag;
-import com.example.LunchGo.tag.repository.SearchTagRepository;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalTime; // Import added
-import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,12 +25,15 @@ import java.util.stream.Collectors;
 public class BusinessRestaurantService {
 
     private final RestaurantRepository restaurantRepository;
-    private final RegularHolidayRepository regularHolidayRepository;
-    // private final RestaurantImageRepository restaurantImageRepository; // Removed
-    private final SearchTagRepository searchTagRepository; // Needed for restaurant tags
+
+    private final MenuService menuService;
+    private final RegularHolidayService regularHolidayService;
+    private final RestaurantTagService restaurantTagService; // SearchTagRepository 대신 RestaurantTagService 주입
+
+    private final ModelMapper modelMapper;
 
     /**
-     * 특정 식당의 상세 정보를 조회합니다. (메뉴 정보 제외)
+     * 특정 식당의 상세 정보를 조회합니다.
      *
      * @param restaurantId 식당 ID
      * @return 식당 상세 정보를 담은 RestaurantDetailResponse DTO
@@ -47,56 +44,22 @@ public class BusinessRestaurantService {
         Restaurant restaurant = restaurantRepository.findByIdWithImages(restaurantId)
                 .orElseThrow(() -> new NoSuchElementException("Restaurant not found with id: " + restaurantId));
 
-        // 2. RegularHoliday 조회
-        List<RegularHoliday> regularHolidays = regularHolidayRepository.findAllByRestaurantId(restaurantId);
+        // 2. 메뉴, 정기 휴무일, 태그 정보는 각 전문 서비스에 위임
+        List<MenuDTO> menuDtos = menuService.getMenusByRestaurant(restaurantId);
+        List<RegularHolidayDTO> regularHolidayDtos = regularHolidayService.getRegularHolidaysByRestaurant(restaurantId);
+        List<RestaurantTagDTO> restaurantTagDtos = restaurantTagService.getTagsByRestaurant(restaurantId); // RestaurantTagService에 위임
 
-        // 3. Restaurant에 매핑된 태그 ID 조회 및 태그 정보 페치
-        List<Long> restaurantTagIds = restaurantRepository.findTagIdsByRestaurantId(restaurantId);
-        Map<Long, SearchTag> allRestaurantTagsMap = searchTagRepository.findAllById(restaurantTagIds)
-                .stream()
-                .collect(Collectors.toMap(SearchTag::getTagId, tag -> tag));
-
-        // 4. DTO 매핑
-        List<ImageDto> imageDtos = restaurant.getRestaurantImages().stream()
-                .map(img -> ImageDto.builder().imageUrl(img.getImageUrl()).build())
+        // 3. DTO 매핑
+        List<ImageDTO> imageDtos = restaurant.getRestaurantImages().stream()
+                .map(img -> ImageDTO.builder().imageUrl(img.getImageUrl()).build())
                 .collect(Collectors.toList());
 
-        List<RestaurantTagDto> restaurantTagDtos = restaurantTagIds.stream()
-                .map(tagId -> {
-                    SearchTag tag = allRestaurantTagsMap.get(tagId);
-                    return tag != null ? RestaurantTagDto.builder()
-                            .tagId(tag.getTagId())
-                            .content(tag.getContent())
-                            .category(tag.getCategory())
-                            .build() : null;
-                })
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-
-        List<RegularHolidayDto> regularHolidayDtos = regularHolidays.stream()
-                .map(holiday -> RegularHolidayDto.builder().dayOfWeek(holiday.getDayOfWeek()).build())
-                .collect(Collectors.toList());
-
-
-        return RestaurantDetailResponse.builder()
-                .restaurantId(restaurant.getRestaurantId())
-                .name(restaurant.getName())
-                .phone(restaurant.getPhone())
-                .roadAddress(restaurant.getRoadAddress())
-                .detailAddress(restaurant.getDetailAddress())
-                .description(restaurant.getDescription())
-                .status(restaurant.getStatus())
-                .avgMainPrice(restaurant.getAvgMainPrice())
-                .reservationLimit(restaurant.getReservationLimit())
-                .holidayAvailable(restaurant.isHolidayAvailable())
-                .preorderAvailable(restaurant.isPreorderAvailable())
-                .openTime(restaurant.getOpenTime().format(DateTimeFormatter.ofPattern("HH:mm")))
-                .closeTime(restaurant.getCloseTime().format(DateTimeFormatter.ofPattern("HH:mm")))
-                .openDate(restaurant.getOpenDate())
-                .images(imageDtos)
-                .tags(restaurantTagDtos)
-                .regularHolidays(regularHolidayDtos)
-                .build();
+        RestaurantDetailResponse response = modelMapper.map(restaurant, RestaurantDetailResponse.class);
+        response.setMenus(menuDtos);
+        response.setImages(imageDtos);
+        response.setTags(restaurantTagDtos);
+        response.setRegularHolidays(regularHolidayDtos);
+        return response;
     }
 
 
@@ -106,56 +69,26 @@ public class BusinessRestaurantService {
         // TODO: 추후 인증(Authentication) 도입 시 실제 ownerId 사용
         long currentOwnerId = 1L;
 
-        Restaurant restaurant = Restaurant.builder()
-                .ownerId(currentOwnerId)
-                .name(request.getName())
-                .phone(request.getPhone())
-                .roadAddress(request.getRoadAddress())
-                .detailAddress(request.getDetailAddress())
-                .description(request.getDescription())
-                .status(RestaurantStatus.OPEN) // 초기 상태는 OPEN
-                .avgMainPrice(0) // 메뉴가 없으므로 초기값은 0
-                .reservationLimit(request.getReservationLimit())
-                .holidayAvailable(request.isHolidayAvailable())
-                .preorderAvailable(request.isPreorderAvailable())
-                .openTime(LocalTime.parse(request.getOpenTime()))
-                .closeTime(LocalTime.parse(request.getCloseTime()))
-                .openDate(request.getOpenDate())
-                .build();
+        Restaurant restaurant = modelMapper.map(request, Restaurant.class);
+        restaurant.setOwnerId(currentOwnerId);
+        restaurant.setStatus(RestaurantStatus.OPEN); // 초기 상태는 OPEN
 
         Restaurant savedRestaurant = restaurantRepository.save(restaurant);
         Long newRestaurantId = savedRestaurant.getRestaurantId();
 
         // 2. 이미지 정보 저장은 ObjectStorage와 연동되어 추후 구현 예정이므로 현재는 건너뜀
         // if (request.getImageUrls() != null && !request.getImageUrls().isEmpty()) {
-        //     request.getImageUrls().forEach(imageUrl -> {
-        //         RestaurantImage image = RestaurantImage.builder()
-        //                 .restaurant(savedRestaurant)
-        //                 .imageUrl(imageUrl)
-        //                 .build();
-        //         restaurantImageRepository.save(image);
-        //     });
+        //     ...
         // }
 
-        // 3. 식당 메뉴 정보 저장 (추후 구현 예정)
+        // 3. 식당 메뉴 정보 저장은 MenuService에 위임
+        menuService.createMenus(newRestaurantId, request.getMenus());
+        
+        // 4. 정기 휴무일 정보 저장은 RegularHolidayService에 위임
+        regularHolidayService.createRegularHolidaysForRestaurant(newRestaurantId, request.getRegularHolidayNumbers());
 
-        // 4. 정기 휴무일 정보 저장
-        if (request.getRegularHolidayNumbers() != null && !request.getRegularHolidayNumbers().isEmpty()) {
-            request.getRegularHolidayNumbers().forEach(dayOfWeek -> {
-                RegularHoliday holiday = RegularHoliday.builder()
-                        .restaurantId(newRestaurantId)
-                        .dayOfWeek(dayOfWeek)
-                        .build();
-                regularHolidayRepository.save(holiday);
-            });
-        }
-
-        // 5. 태그 정보 저장
-        if (request.getSelectedTagIds() != null && !request.getSelectedTagIds().isEmpty()) {
-            request.getSelectedTagIds().forEach(tagId -> {
-                restaurantRepository.saveRestaurantTagMapping(newRestaurantId, tagId);
-            });
-        }
+        // 5. 태그 정보 저장은 RestaurantTagService에 위임
+        restaurantTagService.createTagMappingsForRestaurant(newRestaurantId, request.getSelectedTagIds());
 
         return newRestaurantId;
     }
@@ -167,43 +100,19 @@ public class BusinessRestaurantService {
                 .orElseThrow(() -> new NoSuchElementException("Restaurant not found with id: " + id));
 
         // 2. 기본 정보 업데이트
-        restaurant.setName(request.getName());
-        restaurant.setPhone(request.getPhone());
-        restaurant.setRoadAddress(request.getRoadAddress());
-        restaurant.setDetailAddress(request.getDetailAddress());
-        restaurant.setDescription(request.getDescription());
-        restaurant.setReservationLimit(request.getReservationLimit());
-        restaurant.setHolidayAvailable(request.isHolidayAvailable());
-        restaurant.setPreorderAvailable(request.isPreorderAvailable());
-        restaurant.setOpenTime(LocalTime.parse(request.getOpenTime()));
-        restaurant.setCloseTime(LocalTime.parse(request.getCloseTime()));
-        restaurant.setOpenDate(request.getOpenDate());
+        modelMapper.map(request, restaurant);
 
         // 3. TODO: 식당 이미지 정보 업데이트 (추후 구현)
         // 이미지 파일 처리 로직 (e.g., S3 업로드 및 URL 업데이트) 필요
 
-        // 4. TODO: 식당 메뉴 정보 업데이트 (추후 구현)
-        // 메뉴 추가/수정/삭제 로직 필요
+        // 4. 식당 메뉴 정보 업데이트는 MenuService에 위임
+        menuService.updateMenus(id, request.getMenus());
 
-        // 5. 정기 휴무일 업데이트 (기존 정보 삭제 후 새로 추가)
-        regularHolidayRepository.deleteAllByRestaurantId(id);
-        if (request.getRegularHolidayNumbers() != null && !request.getRegularHolidayNumbers().isEmpty()) {
-            request.getRegularHolidayNumbers().forEach(dayOfWeek -> {
-                RegularHoliday holiday = RegularHoliday.builder()
-                        .restaurantId(id)
-                        .dayOfWeek(dayOfWeek)
-                        .build();
-                regularHolidayRepository.save(holiday);
-            });
-        }
+        // 5. 정기 휴무일 업데이트는 RegularHolidayService에 위임
+        regularHolidayService.updateRegularHolidaysForRestaurant(id, request.getRegularHolidayNumbers());
 
-        // 6. 태그 정보 업데이트 (기존 정보 삭제 후 새로 추가)
-        restaurantRepository.deleteRestaurantTagMappingsByRestaurantId(id);
-        if (request.getSelectedTagIds() != null && !request.getSelectedTagIds().isEmpty()) {
-            request.getSelectedTagIds().forEach(tagId -> {
-                restaurantRepository.saveRestaurantTagMapping(id, tagId);
-            });
-        }
+        // 6. 태그 정보 업데이트는 RestaurantTagService에 위임
+        restaurantTagService.updateTagMappingsForRestaurant(id, request.getSelectedTagIds());
 
         // 변경된 내용을 DB에 즉시 반영하기 위해 save 호출
         restaurantRepository.save(restaurant);

--- a/src/main/java/com/example/LunchGo/restaurant/service/MenuService.java
+++ b/src/main/java/com/example/LunchGo/restaurant/service/MenuService.java
@@ -1,0 +1,168 @@
+package com.example.LunchGo.restaurant.service;
+
+import com.example.LunchGo.restaurant.domain.MenuCategory;
+import com.example.LunchGo.restaurant.dto.MenuDTO;
+import com.example.LunchGo.restaurant.dto.MenuTagDTO;
+import com.example.LunchGo.restaurant.dto.MenuTagMappingDTO;
+import com.example.LunchGo.restaurant.entity.Menu;
+import com.example.LunchGo.restaurant.repository.MenuRepository;
+import com.example.LunchGo.tag.entity.SearchTag;
+import com.example.LunchGo.tag.repository.SearchTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MenuService {
+
+    private final MenuRepository menuRepository;
+    private final SearchTagRepository searchTagRepository;
+    private final ModelMapper modelMapper;
+
+    /**
+     * 특정 식당의 메뉴 리스트를 생성합니다.
+     *
+     * @param restaurantId 메뉴를 추가할 식당 ID
+     * @param menuDtos     생성할 메뉴 정보 DTO 리스트
+     */
+    public void createMenus(Long restaurantId, List<MenuDTO> menuDtos) {
+        if (menuDtos == null || menuDtos.isEmpty()) {
+            return;
+        }
+        for (MenuDTO menuDto : menuDtos) {
+            Menu menu = Menu.builder()
+                    .restaurantId(restaurantId)
+                    .name(menuDto.getName())
+                    .price(menuDto.getPrice())
+                    .category(menuDto.getCategory()) // .findCategory() 호출 제거
+                    .description(menuDto.getDescription() != null ? menuDto.getDescription() : "")
+                    .build();
+            Menu savedMenu = menuRepository.save(menu);
+
+            if (menuDto.getTags() != null && !menuDto.getTags().isEmpty()) {
+                for (MenuTagDTO menuTagDto : menuDto.getTags()) {
+                    if (menuTagDto.getTagId() != null) {
+                        menuRepository.saveMenuTagMapping(savedMenu.getMenuId(), menuTagDto.getTagId());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * 특정 식당의 메뉴 리스트를 업데이트합니다. (변경분 비교 방식 + ModelMapper)
+     *
+     * @param restaurantId    업데이트할 식당 ID
+     * @param updatedMenuDtos 업데이트할 메뉴 정보 DTO 리스트
+     */
+    public void updateMenus(Long restaurantId, List<MenuDTO> updatedMenuDtos) {
+        if (updatedMenuDtos == null) {
+            updatedMenuDtos = new ArrayList<>(); // null이면 빈 리스트로 처리하여 모든 메뉴를 삭제
+        }
+
+        // 1. DB에서 기존 메뉴 목록 조회
+        Map<Long, Menu> existingMenuMap = menuRepository.findAllByRestaurantIdAndIsDeletedFalse(restaurantId)
+                .stream()
+                .collect(Collectors.toMap(Menu::getMenuId, menu -> menu));
+
+        // 2. 요청 DTO에서 메뉴 ID 집합 생성
+        Set<Long> updatedMenuIds = updatedMenuDtos.stream()
+                .map(MenuDTO::getMenuId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        // 3. 신규 및 수정 메뉴 처리
+        for (MenuDTO dto : updatedMenuDtos) {
+            if (dto.getMenuId() == null) {
+                // 신규 메뉴 -> INSERT
+                Menu newMenu = modelMapper.map(dto, Menu.class);
+                newMenu.setRestaurantId(restaurantId); // restaurantId 수동 설정
+
+                Menu savedMenu = menuRepository.save(newMenu);
+                updateMenuTags(savedMenu.getMenuId(), dto.getTags());
+            } else {
+                // 기존 메뉴 -> UPDATE
+                Menu existingMenu = existingMenuMap.get(dto.getMenuId());
+                if (existingMenu != null) {
+                    // ModelMapper를 사용하여 DTO의 값을 기존 엔티티에 매핑 (ID는 변경되지 않음)
+                    modelMapper.map(dto, existingMenu);
+                    menuRepository.save(existingMenu); // 변경된 메뉴를 명시적으로 저장
+                    updateMenuTags(existingMenu.getMenuId(), dto.getTags());
+                }
+            }
+        }
+
+        // 4. 삭제된 메뉴 처리 (차집합 활용)
+        Set<Long> existingMenuIds = new HashSet<>(existingMenuMap.keySet());
+        existingMenuIds.removeAll(updatedMenuIds); // existingMenuIds에 삭제할 ID만 남게 됨
+
+        for (Long menuIdToDelete : existingMenuIds) {
+            menuRepository.softDeleteMenu(restaurantId, menuIdToDelete);
+            menuRepository.deleteMenuTagMappingsByMenuId(menuIdToDelete);
+        }
+    }
+
+    /**
+     * 특정 메뉴의 태그를 업데이트합니다. (기존 태그 모두 삭제 후 새로 추가)
+     *
+     * @param menuId  태그를 업데이트할 메뉴 ID
+     * @param tagDtos 새로운 태그 DTO 리스트
+     */
+    private void updateMenuTags(Long menuId, List<MenuTagDTO> tagDtos) {
+        menuRepository.deleteMenuTagMappingsByMenuId(menuId);
+        if (tagDtos != null && !tagDtos.isEmpty()) {
+            for (MenuTagDTO tagDto : tagDtos) {
+                if (tagDto.getTagId() != null) {
+                    menuRepository.saveMenuTagMapping(menuId, tagDto.getTagId());
+                }
+            }
+        }
+    }
+
+
+    /**
+     * 특정 식당의 메뉴 리스트를 조회합니다. (N+1 문제 해결 버전)
+     *
+     * @param restaurantId 조회할 식당 ID
+     * @return 메뉴 DTO 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<MenuDTO> getMenusByRestaurant(Long restaurantId) {
+        List<Menu> menus = menuRepository.findAllByRestaurantIdAndIsDeletedFalse(restaurantId);
+        if (menus.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Long> menuIds = menus.stream().map(Menu::getMenuId).collect(Collectors.toList());
+        List<MenuTagMappingDTO> mappings = menuRepository.findTagsForMenus(menuIds);
+
+        List<Long> tagIds = mappings.stream().map(MenuTagMappingDTO::getTagId).distinct().collect(Collectors.toList());
+        Map<Long, SearchTag> tagMap = searchTagRepository.findAllById(tagIds).stream()
+                .collect(Collectors.toMap(SearchTag::getTagId, tag -> tag));
+
+        Map<Long, List<Long>> menuIdToTagIdsMap = mappings.stream()
+                .collect(Collectors.groupingBy(MenuTagMappingDTO::getMenuId,
+                        Collectors.mapping(MenuTagMappingDTO::getTagId, Collectors.toList())));
+
+        return menus.stream().map(menu -> {
+            MenuDTO menuDto = modelMapper.map(menu, MenuDTO.class);
+            List<Long> relatedTagIds = menuIdToTagIdsMap.getOrDefault(menu.getMenuId(), Collections.emptyList());
+            List<MenuTagDTO> menuTagDtos = relatedTagIds.stream()
+                    .map(tagId -> {
+                        SearchTag tag = tagMap.get(tagId);
+                        return tag != null ? modelMapper.map(tag, MenuTagDTO.class) : null;
+                    })
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+            menuDto.setTags(menuTagDtos);
+            return menuDto;
+        }).collect(Collectors.toList());
+    }
+}
+

--- a/src/main/java/com/example/LunchGo/restaurant/service/RegularHolidayService.java
+++ b/src/main/java/com/example/LunchGo/restaurant/service/RegularHolidayService.java
@@ -1,0 +1,62 @@
+package com.example.LunchGo.restaurant.service;
+
+import com.example.LunchGo.restaurant.dto.RegularHolidayDTO;
+import com.example.LunchGo.restaurant.entity.RegularHoliday;
+import com.example.LunchGo.restaurant.repository.RegularHolidayRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RegularHolidayService {
+
+    private final RegularHolidayRepository regularHolidayRepository;
+    private final ModelMapper modelMapper;
+
+    /**
+     * 특정 식당의 정기 휴무일 리스트를 조회합니다.
+     * @param restaurantId 조회할 식당 ID
+     * @return 정기 휴무일 DTO 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<RegularHolidayDTO> getRegularHolidaysByRestaurant(Long restaurantId) {
+        return regularHolidayRepository.findAllByRestaurantId(restaurantId)
+                .stream()
+                .map(holiday -> modelMapper.map(holiday, RegularHolidayDTO.class))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 식당의 정기 휴무일 리스트를 생성합니다.
+     * @param restaurantId 정기 휴무일을 추가할 식당 ID
+     * @param regularHolidayNumbers 생성할 정기 휴무일(요일 숫자) 리스트
+     */
+    public void createRegularHolidaysForRestaurant(Long restaurantId, List<Integer> regularHolidayNumbers) {
+        if (regularHolidayNumbers == null || regularHolidayNumbers.isEmpty()) {
+            return;
+        }
+        regularHolidayNumbers.forEach(dayOfWeek -> {
+            RegularHoliday holiday = RegularHoliday.builder()
+                    .restaurantId(restaurantId)
+                    .dayOfWeek(dayOfWeek)
+                    .build();
+            regularHolidayRepository.save(holiday);
+        });
+    }
+
+    /**
+     * 특정 식당의 정기 휴무일을 업데이트합니다. (기존 정보 전체 삭제 후 새로 추가)
+     * @param restaurantId 업데이트할 식당 ID
+     * @param regularHolidayNumbers 새로운 정기 휴무일(요일 숫자) 리스트
+     */
+    public void updateRegularHolidaysForRestaurant(Long restaurantId, List<Integer> regularHolidayNumbers) {
+        regularHolidayRepository.deleteAllByRestaurantId(restaurantId);
+        createRegularHolidaysForRestaurant(restaurantId, regularHolidayNumbers);
+    }
+}

--- a/src/main/java/com/example/LunchGo/restaurant/service/RestaurantTagService.java
+++ b/src/main/java/com/example/LunchGo/restaurant/service/RestaurantTagService.java
@@ -1,0 +1,70 @@
+package com.example.LunchGo.restaurant.service;
+
+import com.example.LunchGo.restaurant.dto.RestaurantTagDTO;
+import com.example.LunchGo.restaurant.repository.RestaurantRepository;
+import com.example.LunchGo.tag.entity.SearchTag;
+import com.example.LunchGo.tag.repository.SearchTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RestaurantTagService {
+
+    private final RestaurantRepository restaurantRepository;
+    private final SearchTagRepository searchTagRepository;
+    private final ModelMapper modelMapper;
+
+    /**
+     * 특정 식당에 연결된 태그 리스트를 조회합니다.
+     * @param restaurantId 조회할 식당 ID
+     * @return 식당 태그 DTO 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<RestaurantTagDTO> getTagsByRestaurant(Long restaurantId) {
+        List<Long> restaurantTagIds = restaurantRepository.findTagIdsByRestaurantId(restaurantId);
+        Map<Long, SearchTag> allRestaurantTagsMap = searchTagRepository.findAllById(restaurantTagIds)
+                .stream()
+                .collect(Collectors.toMap(SearchTag::getTagId, tag -> tag));
+
+        return restaurantTagIds.stream()
+                .map(tagId -> {
+                    SearchTag tag = allRestaurantTagsMap.get(tagId);
+                    return tag != null ? modelMapper.map(tag, RestaurantTagDTO.class) : null;
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 식당에 태그 매핑을 생성합니다.
+     * @param restaurantId 매핑을 생성할 식당 ID
+     * @param selectedTagIds 선택된 태그 ID 리스트
+     */
+    public void createTagMappingsForRestaurant(Long restaurantId, List<Long> selectedTagIds) {
+        if (selectedTagIds == null || selectedTagIds.isEmpty()) {
+            return;
+        }
+        selectedTagIds.forEach(tagId -> {
+            restaurantRepository.saveRestaurantTagMapping(restaurantId, tagId);
+        });
+    }
+
+    /**
+     * 특정 식당의 태그 매핑을 업데이트합니다. (기존 매핑 전체 삭제 후 새로 추가)
+     * @param restaurantId 매핑을 업데이트할 식당 ID
+     * @param selectedTagIds 새로운 태그 ID 리스트
+     */
+    public void updateTagMappingsForRestaurant(Long restaurantId, List<Long> selectedTagIds) {
+        restaurantRepository.deleteRestaurantTagMappingsByRestaurantId(restaurantId);
+        createTagMappingsForRestaurant(restaurantId, selectedTagIds);
+    }
+}

--- a/src/main/java/com/example/LunchGo/tag/dto/SearchTagDTO.java
+++ b/src/main/java/com/example/LunchGo/tag/dto/SearchTagDTO.java
@@ -1,5 +1,6 @@
 package com.example.LunchGo.tag.dto;
 
+import com.example.LunchGo.tag.domain.TagCategory;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,4 +10,5 @@ public class SearchTagDTO {
 
     private Long tagId;
     private String content;
+    private TagCategory category;
 }

--- a/src/main/java/com/example/LunchGo/tag/entity/SearchTag.java
+++ b/src/main/java/com/example/LunchGo/tag/entity/SearchTag.java
@@ -30,6 +30,6 @@ public class SearchTag {
     private TagCategory category;
 
     public SearchTagDTO to() {
-        return new SearchTagDTO(tagId, content);
+        return new SearchTagDTO(tagId, content, category);
     }
 }


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- ModelMapper 의존성 추가
- 사업자용 식당정보 백엔드-프론트엔드 연동 과정에서 BusinessRestaurantService에서 식당메뉴 관련 서비스 로직 분리
- 기존 식당정보 조회/등록/수정 로직에 식당메뉴 조회/등록/수정 로직 추가
- 사업자 전용 식당 기본정보, 정기휴무일, 검색태그, 식당메뉴 조회/등록/수정 관련 백엔드 로직을 프론트엔드에 연동
- 식당메뉴 태그 매핑 정보 조회/등록/수정 로직 추가
- BusinessRestaurantService에서 정기휴무일, 식당메뉴, 식당에 매핑된 태그 관련 서비스 로직 분리

- 이미지 관련 로직은 별도 추가 예정

## 📁 변경된 파일

* 공통
  - src/main/java/com/example/LunchGo/common/config/ModelMapperConfig.java

* 프론트엔드 관련
  - frontend/src/router/index.js
  - frontend/src/stores/restaurant.js
  - frontend/src/views/business/restaurant-info/RestaurantInfoPage.vue

* 백엔드 관련
  - 식당메뉴 dto 추가 및 기존 dto 수정
  - src/main/java/com/example/LunchGo/restaurant/controller/MenuController.java
  - src/main/java/com/example/LunchGo/restaurant/service/MenuService.java
  - src/main/java/com/example/LunchGo/restaurant/service/BusinessRestaurantService.java
  - src/main/java/com/example/LunchGo/restaurant/repository/MenuRepository.java

## 공유사항 to 리뷰어 <!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요.-->

## 🔗 관련 Issue(선택)

- [[FEATURE] 사업자용 식당메뉴 리스트 조회/등록/수정 기능 추가 #226](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/226)

## ✔️ 체크리스트(선택)

- https://www.notion.so/2d7f68be60378048bffbd8e6e2312034?source=copy_link
