### PR TITLE
feat(promotion): 사업자 프로모션 등록 시 메일 전송 프론트-백 연결

### DIFF
--- a/frontend/src/views/business/promotion/BusinessPromotionPage.vue
+++ b/frontend/src/views/business/promotion/BusinessPromotionPage.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, TrackOpTypes } from 'vue';
 import BusinessSidebar from '@/components/ui/BusinessSideBar.vue';
 import BusinessHeader from '@/components/ui/BusinessHeader.vue';
+import axios from 'axios';
 
 // --- 상태 관리 변수 ---
 const isPromotionOn = ref(false); // 프로모션 여부 (기본값 끄기)
@@ -28,12 +29,37 @@ const handleRegister = async () => {
     return;
   }
 
-  //백엔드 전송 로직
+  const ownerId = 1; //pinia 사용하기
 
-  // 성공 처리
-  errorMsg.value = '';
-  showSuccessMessage.value = true;
-  setTimeout(() => (showSuccessMessage.value = false), 3000);
+  //백엔드 전송 로직
+  try {
+    await axios.post("/api/business/promotion", {
+      ownerId: ownerId,
+      title: promotionTitle.value,
+      content: promotionContent.value
+    });
+
+    // 성공 처리
+    errorMsg.value = '';
+    showSuccessMessage.value = true;
+    setTimeout(() => (showSuccessMessage.value = false), 3000);
+  }catch(error){
+    const status = error.response.status;
+
+    switch(status){
+      case 400:
+        alert("[400 Bad Request] 잘못된 요청입니다. 입력값을 확인해주세요.");
+        break;
+      case 404:
+        alert("[404 Not Found] 해당 사업자가 존재하지 않습니다.");
+        break;
+      case 429:
+        alert("[429 Too Many Requests] 프로모션은 6시간 간격으로 전송가능합니다.");
+        break;
+      default:
+        alert(`오류가 발생했습니다. (Code: ${status})`);
+    }
+  }
 };
 
 // 입력 시 에러 메시지 초기화


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 사업자가 프로모션 관리 페이지에서 프로모션 내용을 적고 메일 전송 시 즐겨찾기 등록한 사용자에게 메일 전송

## 📁 변경된 파일

- BusinessPromotionPage.vue

## 🔗 관련 Issue(선택)

- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/246

## ✔️ 체크리스트(선택)

- title에 적은건 메일 제목으로, 내용으로 적은건 mail 내용으로 들어오도록 구성
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/fe1bbc4e-e1eb-4ead-b875-89f403d9882c" />

