### PR TITLE
feat: 식당 이미지 API 연동 (메인/상세)

### DIFF
--- a/frontend/src/views/restaurant/id/RestaurantDetailPage.vue
+++ b/frontend/src/views/restaurant/id/RestaurantDetailPage.vue
@@ -191,6 +191,33 @@ const toggleRestaurantFavorite = () => {
   isRestaurantFavorite.value = !isRestaurantFavorite.value;
 };
 
+const applyRestaurantImages = (imageUrls = []) => {
+  if (!Array.isArray(imageUrls) || imageUrls.length === 0) return;
+  restaurantImages.value = imageUrls.map((url, index) => ({
+    url,
+    alt: `${restaurantInfo.value?.name || '식당'} 이미지 ${index + 1}`,
+  }));
+  restaurantInfo.value = {
+    ...restaurantInfo.value,
+    image: imageUrls[0],
+    gallery: imageUrls,
+  };
+};
+
+const loadRestaurantImages = async () => {
+  try {
+    const response = await axios.get(
+      `/api/business/restaurants/${restaurantId}/images`,
+    );
+    const imageUrls = (response.data || [])
+      .map((item) => item?.imageUrl)
+      .filter(Boolean);
+    applyRestaurantImages(imageUrls);
+  } catch (error) {
+    console.error('식당 이미지 데이터를 불러오지 못했습니다:', error);
+  }
+};
+
 const loadRepresentativeReviews = async () => {
   try {
     const response = await axios.get(`/api/restaurants/${restaurantId}/reviews`, {
@@ -338,6 +365,7 @@ onMounted(() => {
   });
   initializeDetailMap();
   loadRepresentativeReviews();
+  loadRestaurantImages();
 });
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 메인 리스트에서 /api/business/restaurants/{id}/images 첫 이미지를 가져와 카드 이미지로 표시
- 식당 상세 페이지에서 이미지 목록을 불러와 갤러리에 표시

## 📁 변경된 파일

- frontend/src/views/HomeView.vue
- frontend/src/views/restaurant/id/RestaurantDetailPage.vue

<img width="796" height="568" alt="image" src="https://github.com/user-attachments/assets/e44d63d1-8b2e-4a49-b405-c352cf8ea128" />

test 이미지입니다.
<img width="514" height="427" alt="image" src="https://github.com/user-attachments/assets/4e8cf484-3ae8-4c3e-b6c9-5019da65b9e3" />

