### PR TITLE
feat: 식당 상세 상단 고정 및 메뉴 중복 이슈 대응

### DIFF
--- a/frontend/src/views/restaurant/id/RestaurantDetailPage.vue
+++ b/frontend/src/views/restaurant/id/RestaurantDetailPage.vue
@@ -359,6 +359,9 @@ const changeDetailMapDistance = (delta) => {
 
 // 컴포넌트 마운트 후 드래그 스크롤 및 지도 설정
 onMounted(() => {
+  if (typeof window !== 'undefined') {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }
   const scrollContainers = document.querySelectorAll('.review-image-scroll');
   scrollContainers.forEach((container) => {
     setupDragScroll(container);

--- a/src/main/resources/sql/tables_create_restaurant_info.sql
+++ b/src/main/resources/sql/tables_create_restaurant_info.sql
@@ -73,7 +73,6 @@ CREATE TABLE restaurant_images
 
 
 -- 4. 식당 메뉴
-DROP TABLE IF EXISTS menus;
 CREATE TABLE menus
 (
     menu_id       BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '식당메뉴ID',


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 식당 상세 페이지 진입 시 스크롤을 항상 상단으로 이동하도록 수정
- menus 테이블에 데이터가 2번 들어가서 식당메뉴에 중복으로 표시되는 오류 해결

## 📁 변경된 파일

- frontend/src/views/restaurant/id/RestaurantDetailPage.vue


