### PR TITLE
feat: 메인 리스트 평점/리뷰수 연동 및 페이지네이션 개선

### DIFF
--- a/frontend/src/components/ui/AppHeader.vue
+++ b/frontend/src/components/ui/AppHeader.vue
@@ -38,7 +38,7 @@ const handleLogout = async () => {
           alt="런치고"
           width="56"
           height="56"
-          class="w-14 h-14 object-contain"
+          class="w-14 h-14 object-contain -ml-2"
         />
         <RouterLink
           to="/intro"

--- a/frontend/src/components/ui/RestaurantCardList.vue
+++ b/frontend/src/components/ui/RestaurantCardList.vue
@@ -59,6 +59,11 @@ const formatTagLabel = (tag) => {
   }
   return `${tag.name} ${tag.count}`;
 };
+
+const formatRating = (rating) => {
+  const value = Number(rating);
+  return Number.isFinite(value) ? value.toFixed(1) : "-";
+};
 </script>
 
 <template>
@@ -115,9 +120,9 @@ const formatTagLabel = (tag) => {
             </p>
             <div class="flex items-center gap-1 mb-1.5">
               <Star class="w-3.5 h-3.5 fill-[#ffc107] text-[#ffc107]" />
-              <span class="text-sm font-medium text-[#1e3a5f]">{{
-                restaurant.rating ?? "-"
-              }}</span>
+              <span class="text-sm font-medium text-[#1e3a5f]">
+                {{ formatRating(restaurant.rating) }}
+              </span>
               <span class="text-xs text-[#6c757d]"
                 >(리뷰수 : {{ restaurant.reviews ?? 0 }})</span
               >

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,6 +5,12 @@ import { useRestaurantStore } from '@/stores/restaurant';
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition;
+    }
+    return { left: 0, top: 0 };
+  },
   routes: [
     {
       path: '/',

--- a/frontend/src/views/restaurant/id/RestaurantDetailPage.vue
+++ b/frontend/src/views/restaurant/id/RestaurantDetailPage.vue
@@ -94,11 +94,10 @@ const highlightTags = computed(() => {
 const restaurantName = computed(() => restaurantInfo.value?.name || '식당명');
 
 const ratingDisplay = computed(() => {
-  const rating = restaurantInfo.value?.rating;
-  if (typeof rating === 'number') {
-    return rating.toFixed(1);
-  }
-  return '0.0';
+  const summaryRating = restaurantReviewSummary.value?.avgRating;
+  const rawRating = summaryRating ?? restaurantInfo.value?.rating;
+  const value = Number(rawRating);
+  return Number.isFinite(value) ? value.toFixed(1) : '0.0';
 });
 
 const reviewCountDisplay = computed(() => restaurantReviewSummary.value?.reviewCount ?? restaurantInfo.value?.reviews ?? 0);


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

-메인 로고를 왼쪽으로 더 이동
- 메인 리스트 평점 표시를 소수 1자리로 통일
- 페이지네이션을 5페이지 단위로 묶고, 페이지 이동 시 스크롤 유지
- 리뷰 요약(평점/리뷰수) 불러와 메인 리스트와 지도 모달에 반영
- 라우트 이동 시 스크롤 상단 이동 적용
- 식당 상세 상단 평점에 리뷰 요약 평균값 우선 표시

## 📁 변경된 파일

- frontend/src/components/ui/AppHeader.vue
- frontend/src/components/ui/RestaurantCardList.vue
- frontend/src/router/index.js
- frontend/src/views/HomeView.vue
- frontend/src/views/restaurant/id/RestaurantDetailPage.vue
