### PR TITLE
feat: 메뉴 상세 화면 정돈과 네비/헤더 UI 정렬

### DIFF
--- a/frontend/src/components/ui/AppFooter.vue
+++ b/frontend/src/components/ui/AppFooter.vue
@@ -8,10 +8,14 @@ import { RouterLink } from 'vue-router';
       <p class="font-semibold text-[#1e3a5f]">(주) 런치고</p>
       <p>주소 : 경기도 성남시 분당구 대왕판교로 ~~</p>
       <p>
-        서비스 이용 약관 | 개인정보 처리방침 | 위치정보 이용약관 | 환불 정책 |
+        <RouterLink to="/intro" class="hover:underline">서비스 소개</RouterLink> |
+        서비스 이용 약관 | 환불 정책 |
         <RouterLink to="/partner" class="text-[#FF6B4A] hover:underline">
           입점 문의
         </RouterLink>
+      </p>
+      <p>
+        개인정보 처리방침 | 위치정보 이용약관
       </p>
     </div>
   </footer>

--- a/frontend/src/components/ui/AppHeader.vue
+++ b/frontend/src/components/ui/AppHeader.vue
@@ -40,21 +40,17 @@ const handleLogout = async () => {
           height="56"
           class="w-14 h-14 object-contain -ml-2"
         />
-        <RouterLink
-          to="/intro"
-          class="font-semibold text-[#1e3a5f] text-base hover:text-[#ff6b4a] transition-colors"
-        >
-          서비스 소개
-        </RouterLink>
+      </div>
+      <div class="flex-1 px-4">
+        <input
+          type="text"
+          placeholder="검색"
+          class="w-full h-9 px-3 rounded-full border border-[#ced4da] bg-[#e9ecef] text-sm text-[#495057] focus:outline-none focus:ring-2 focus:ring-[#ff6b4a]"
+        />
       </div>
 
       <div class="flex items-center gap-4">
         <template v-if="isLoggedIn">
-          <span class="text-sm font-medium text-[#495057]">
-            <span class="text-[#1e3a5f] font-bold">{{ userName }}</span
-            >님 안녕하세요!
-          </span>
-
           <div class="relative">
             <button
               @click="toggleMenu"

--- a/frontend/src/components/ui/BottomNav.vue
+++ b/frontend/src/components/ui/BottomNav.vue
@@ -8,7 +8,7 @@ import { Calendar, Home, User } from 'lucide-vue-next';
     <div class="max-w-[500px] mx-auto flex items-center justify-around h-16 px-4">
       <RouterLink
         to="/my-reservations"
-        class="flex items-center justify-center text-[#ff6b4a] hover:text-[#FF8A6D] transition-colors min-w-[60px]"
+        class="flex items-center justify-center -mt-4 text-[#ff6b4a] hover:text-[#FF8A6D] transition-colors min-w-[60px]"
       >
         <Calendar class="w-6 h-6" />
       </RouterLink>
@@ -29,7 +29,7 @@ import { Calendar, Home, User } from 'lucide-vue-next';
 
       <RouterLink
         to="/mypage"
-        class="flex items-center justify-center text-[#ff6b4a] hover:text-[#FF8A6D] transition-colors min-w-[60px]"
+        class="flex items-center justify-center -mt-4 text-[#ff6b4a] hover:text-[#FF8A6D] transition-colors min-w-[60px]"
       >
         <User class="w-6 h-6" />
       </RouterLink>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -575,6 +575,18 @@ const renderMapMarkers = async (kakaoMaps) => {
   mapMarkers.forEach((marker) => marker.setMap(null));
   mapMarkers.length = 0;
 
+  const markerSvg =
+    "data:image/svg+xml;utf8," +
+    "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='46' viewBox='0 0 32 46'>" +
+    "<path d='M16 1C8.8 1 3 6.8 3 14c0 9.3 13 30 13 30s13-20.7 13-30C29 6.8 23.2 1 16 1z' fill='%23ff6b4a' stroke='white' stroke-width='2'/>" +
+    "<circle cx='16' cy='14' r='5' fill='white'/>" +
+    "</svg>";
+  const markerImage = new kakaoMaps.MarkerImage(
+    markerSvg,
+    new kakaoMaps.Size(32, 46),
+    { offset: new kakaoMaps.Point(16, 46) }
+  );
+
   const distanceLimit = selectedDistanceKm.value;
 
   for (const restaurant of restaurants) {
@@ -587,6 +599,7 @@ const renderMapMarkers = async (kakaoMaps) => {
     const marker = new kakaoMaps.Marker({
       position: new kakaoMaps.LatLng(coords.lat, coords.lng),
       title: restaurant.name,
+      image: markerImage,
     });
 
     try {

--- a/frontend/src/views/restaurant/id/RestaurantDetailPage.vue
+++ b/frontend/src/views/restaurant/id/RestaurantDetailPage.vue
@@ -318,6 +318,18 @@ const initializeDetailMap = async () => {
       restaurantInfo.value.coords.lng,
     );
 
+    const markerSvg =
+      "data:image/svg+xml;utf8," +
+      "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='46' viewBox='0 0 32 46'>" +
+      "<path d='M16 1C8.8 1 3 6.8 3 14c0 9.3 13 30 13 30s13-20.7 13-30C29 6.8 23.2 1 16 1z' fill='%23ff6b4a' stroke='white' stroke-width='2'/>" +
+      "<circle cx='16' cy='14' r='5' fill='white'/>" +
+      "</svg>";
+    const markerImage = new kakaoMaps.MarkerImage(
+      markerSvg,
+      new kakaoMaps.Size(32, 46),
+      { offset: new kakaoMaps.Point(16, 46) },
+    );
+
     detailMapInstance = new kakaoMaps.Map(detailMapContainer.value, {
       center,
       level: detailLevelForDistance(detailMapDistanceStepIndex.value),
@@ -327,6 +339,7 @@ const initializeDetailMap = async () => {
     detailMarker = new kakaoMaps.Marker({
       position: center,
       title: restaurantName.value,
+      image: markerImage,
     });
 
     detailMarker.setMap(detailMapInstance);


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 메뉴 전체보기 페이지를 선주문 UI가 아닌 읽기 전용 메뉴 목록으로 변경
- 하단 네비 양쪽 버튼 높이 홈 버튼과 정렬
- 상단 헤더에서 “서비스 소개” 제거, 검색바 추가 및 톤 조정
- 푸터에 “서비스 소개” 추가, 약관/정책 문구 두 줄로 재배치
- 지도 마커를 오렌지 핀 SVG로 변경(메인/상세)

## 📁 변경된 파일

- frontend/src/views/restaurant/id/menus/RestaurantMenusPage.vue
- frontend/src/components/ui/BottomNav.vue
- frontend/src/components/ui/AppHeader.vue
- frontend/src/components/ui/AppFooter.vue
- frontend/src/views/HomeView.vue
- frontend/src/views/restaurant/id/RestaurantDetailPage.vue

