### PR TITLE
feat(security): 스프링 시큐리티 적 및 프론트 및 백엔드 연동 작업 완료

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,17 +251,17 @@
 
 ---
 
-## 📁 프로젝트 구조
+## 📁 프로젝트 구조 (현재 코드 기준)
 
 ### 전체 디렉토리 구조
 
 ```
-/webapp/
+/LunchGO/
 ├── frontend/              # Vue3 프론트엔드
 ├── src/                   # Spring Boot 백엔드
+├── docs/                  # 기술 문서
+├── scripts/               # 유틸리티 스크립트
 ├── gradle/                # Gradle 빌드 설정
-├── .git/                  # Git 저장소
-├── .husky/                # Git Hooks 설정
 ├── README.md              # 프로젝트 문서
 ├── package.json           # 루트 패키지 (commitlint, husky)
 ├── build.gradle           # Gradle 빌드 파일
@@ -300,8 +300,6 @@ frontend/
 │   └── main.js                   # 앱 엔트리 포인트
 │
 ├── public/                       # 정적 파일
-│   └── images/                   # 이미지 파일
-│
 ├── package.json                  # 프론트엔드 의존성
 ├── vite.config.js                # Vite 빌드 설정
 ├── tailwind.config.js            # Tailwind CSS 설정
@@ -315,11 +313,11 @@ frontend/
 src/
 ├── main/
 │   ├── java/com/example/LunchGo/
-│   │   ├── account/              # 계정 찾기/가입 보조 로직
-│   │   ├── bookmark/             # 즐겨찾기
+│   │   ├── account/              # 로그인/JWT/계정 보조
+│   │   ├── block/                # 차단 관련 로직
+│   │   ├── bookmark/             # 즐겨찾기/공유
 │   │   ├── cafeteria/            # 구내식당 메뉴/추천
-│   │   ├── common/               # 공통 설정/유틸
-│   │   ├── config/               # MyBatis 설정
+│   │   ├── common/               # 공통 설정/유틸/보안 설정
 │   │   ├── email/                # 이메일 인증/프로모션
 │   │   ├── image/                # 이미지 업로드/오브젝트 스토리지
 │   │   ├── member/               # 회원/사업자/직원
@@ -413,8 +411,8 @@ src/
 
 | 모듈 | 컨트롤러 | 설명 |
 | ---- | -------- | ---- |
-| account | AccountController | 아이디/비밀번호 찾기 등 계정 보조 기능 |
-| bookmark | BookmarkController | 즐겨찾기 CRUD |
+| account | AccountController | 로그인/토큰/계정 보조 기능 |
+| bookmark | BookmarkController, BookmarkLinkController | 즐겨찾기 CRUD, 즐겨찾기 공유/링크 |
 | cafeteria | CafeteriaMenuController | 구내식당 메뉴 조회/추천 |
 | email | EmailController | 이메일 인증/프로모션 발송 |
 | image | ImageUploadController | 이미지 업로드/프리사인 URL |
@@ -426,6 +424,14 @@ src/
 | tag | SearchTagController | 검색 태그 조회 |
 
 ---
+
+## 🔐 보안 구성 요소 (Spring Security/JWT)
+
+- Security 설정: `src/main/java/com/example/LunchGo/common/config/SecurityConfig.java`
+- JWT 필터: `src/main/java/com/example/LunchGo/account/helper/JwtFilter.java`
+- 인증 진입점/핸들러: `src/main/java/com/example/LunchGo/common/exception/JwtAuthenticationEntryPoint.java`, `src/main/java/com/example/LunchGo/common/exception/JwtAccessDeniedHandler.java`
+- UserDetails/서비스: `src/main/java/com/example/LunchGo/account/dto/CustomUserDetails.java`, `src/main/java/com/example/LunchGo/account/service/CustomUserDetailsService.java`
+- 토큰 유틸: `src/main/java/com/example/LunchGo/common/util/TokenUtils.java`
 
 ## 🔀 Git 브랜치 전략
 

--- a/docs/kwp-security-implementation.md
+++ b/docs/kwp-security-implementation.md
@@ -1,0 +1,212 @@
+# 스프링 시큐리티 적용 분석 및 구현 계획
+
+## 분석 요약 (현재 상태)
+
+- 인증 방식: JWT Access Token(헤더), Refresh Token(HttpOnly 쿠키)
+- 필터/설정
+  - `src/main/java/com/example/LunchGo/common/config/SecurityConfig.java`
+  - `src/main/java/com/example/LunchGo/account/helper/JwtFilter.java`
+  - `src/main/java/com/example/LunchGo/common/exception/JwtAuthenticationEntryPoint.java`
+  - `src/main/java/com/example/LunchGo/common/exception/JwtAccessDeniedHandler.java`
+- 토큰 유틸/저장
+  - `src/main/java/com/example/LunchGo/common/util/TokenUtils.java` (Redis에 refresh 저장)
+  - `src/main/java/com/example/LunchGo/common/util/HttpUtils.java` (Authorization/쿠키 처리)
+- 로그인/갱신 흐름
+  - 로그인: `/api/login` -> accessToken 응답 + refreshToken 쿠키 저장
+  - 갱신: `/api/refresh` -> accessToken 재발급
+  - 로그아웃: `/api/logout` -> Redis refresh 삭제 + 쿠키 제거
+- 프론트 동작
+  - `frontend/src/router/httpRequest.js`에서 accessToken 부착, 401 시 `/api/refresh` 자동 재발급
+  - `frontend/src/router/index.js`에서 meta.roles 기반 라우트 가드 + `/api/auth/check` 호출
+
+## 오늘의 구현 목표
+
+- `api_specification.csv`에 내가 작업한 API들의 보안/권한 정보를 정확히 기재한다.
+- 실제 인증 흐름(JWT, refresh cookie)과 권한 체계를 문서/스펙에 반영한다.
+- CSV의 “필요 권한” 표기와 `SecurityConfig`의 접근 정책을 일치시키는 기준을 만든다.
+
+## 작업 순서
+
+1) permitAll 후보 확정(Any)  
+   - `api_specification.csv`에서 `필요 권한=Any`만 추려 URI 리스트화
+   - 컨트롤러 실제 경로와 매칭하여 permitAll 범위 확정
+
+2) 기본 인증 규칙 확정  
+   - permitAll 외는 기본 `authenticated()`로 처리
+   - 역할 정의: `ROLE_USER`, `ROLE_OWNER`, `ROLE_STAFF`, `ROLE_ADMIN`
+
+3) 역할 매핑 기준 수립  
+   - 로그인 필요(Authenticated) vs 역할 제한(ROLE_*) 기준 정의
+   - 복수 권한은 `|` 구분 표기 (예: `User|Owner`)
+
+4) `api_specification.csv` 갱신  
+   - “필요 권한” 컬럼을 위 기준으로 일관되게 업데이트
+
+5) 보안 설정 정합성 확인  
+   - `SecurityConfig`의 requestMatchers/권한 설정이 CSV와 어긋나지 않는지 확인
+   - 필요 시 역할별 접근 제어 룰을 추가로 설계(메서드 보안 또는 URL 기반)
+
+## 구현 진행 순서 (백엔드 → 프론트)
+
+1) 백엔드 권한 매핑 적용  
+   - `SecurityConfig`에 permitAll/ROLE_* 매핑 확정 적용
+   - 401/403 처리 응답 확인
+
+2) 프론트 인증 흐름 점검  
+   - `httpRequest` 토큰 부착/리프레시 로직 확인
+   - 라우터 `meta.roles`와 API 권한 정책 정합성 확인
+
+3) 스펙 최종 검증  
+   - `api_specification.csv` 권한 표기와 실제 보안 설정 일치 여부 확인
+
+## SecurityConfig 적용 목록 (CSV 기준)
+
+- permitAll
+  - GET `/api/restaurants/*/reviews`
+  - GET `/api/restaurants/*/reviews/*`
+  - GET `/api/restaurants/trending`
+  - POST `/api/payments/portone/webhook`
+  - 기존 공개 경로: `/api/join/**`, `/api/auth/**`, `/api/sms/**`, `/api/login`
+- ROLE_USER
+  - 리뷰: POST `/api/restaurants/*/reviews`, GET `/api/restaurants/*/reviews/*/edit`, PUT/DELETE `/api/restaurants/*/reviews/*`
+  - 이미지/영수증: POST `/api/v1/images/upload/*`, GET `/api/v1/images/presign`, POST `/api/ocr/receipt`
+  - 결제/예약: POST `/api/reservations/*/payments`, POST `/api/payments/portone/complete|fail|requested`, POST `/api/reservations/*/payments/expire`, GET `/api/reservations/*/confirmation|summary`
+  - 구내식당: POST `/api/cafeteria/menus/ocr|confirm`, GET `/api/cafeteria/menus/week`, GET `/api/cafeteria/recommendations`
+  - 즐겨찾기: POST `/api/bookmark-links`, PATCH `/api/bookmark-links/*`, GET `/api/bookmark-links/sent|received|search|search/list`, DELETE `/api/bookmark-links`, PATCH `/api/bookmark/visibility|promotion`, GET `/api/bookmark/shared|list`
+- ROLE_OWNER
+  - 댓글/블라인드: POST `/api/owners/restaurants/*/reviews/*/comments`, DELETE `/api/owners/restaurants/*/reviews/*/comments/*`, POST `/api/owners/restaurants/*/reviews/*/blind-requests`
+  - 사업자 식당 상세: GET `/api/business/restaurants/*`
+- ROLE_ADMIN
+  - 리뷰 관리: GET `/api/admin/reviews`, PATCH `/api/admin/reviews/*/blind-requests`
+
+## 프론트 인증 대상 파일 (CSV 기준)
+
+- 인증 필요(ROLE_USER)
+  - `frontend/src/composables/useCafeteriaRecommendation.js`
+  - `frontend/src/composables/useBookmarkShare.js`
+  - `frontend/src/views/restaurant/id/reviews/WriteReviewPage.vue`
+  - `frontend/src/views/restaurant/id/payment/RestaurantPaymentPage.vue`
+  - `frontend/src/views/restaurant/id/confirmation/RestaurantConfirmationPage.vue`
+  - `frontend/src/views/my-reservations/ReservationCancelView.vue`
+  - `frontend/src/components/ui/FavoriteHeart.vue`
+- 인증 필요(ROLE_OWNER)
+  - `frontend/src/views/business/reviews/BusinessReviewsPage.vue`
+- 인증 필요(ROLE_ADMIN)
+  - `frontend/src/views/admin/reviews/AdminReviewsPage.vue`
+- public(API Any, axios 사용 유지)
+  - `frontend/src/views/restaurant/id/reviews/RestaurantReviewsPage.vue`
+  - `frontend/src/views/HomeView.vue`
+  - `frontend/src/composables/useTrendingRestaurants.js`
+
+---
+
+## 이번 작업 반영 내역 (상세)
+
+### 1) SecurityConfig 권한 매핑 적용
+
+- permitAll 추가(공개 API 및 리프레시)
+  - `/api/join/**`, `/api/auth/**`, `/api/sms/**`, `/api/login`
+  - GET `/api/restaurants/*/reviews`, GET `/api/restaurants/*/reviews/*`
+  - GET `/api/restaurants/trending`
+  - POST `/api/payments/portone/webhook`
+  - POST `/api/refresh` (refresh 토큰 재발급)
+
+- ROLE_USER / ROLE_OWNER / ROLE_ADMIN 매핑  
+  - CSV의 “필요 권한” 기준으로 requestMatchers에 추가
+
+코드 변경 요약 예시:
+```java
+// src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
+.requestMatchers("/api/join/**", "/api/auth/**", "/api/sms/**", "/api/login").permitAll()
+.requestMatchers("/api/refresh").permitAll()
+.requestMatchers(HttpMethod.GET,
+        "/api/restaurants/*/reviews",
+        "/api/restaurants/*/reviews/*",
+        "/api/restaurants/trending"
+).permitAll()
+.requestMatchers(HttpMethod.POST, "/api/payments/portone/webhook").permitAll()
+
+// USER 권한
+.requestMatchers(HttpMethod.POST, "/api/restaurants/*/reviews").hasAuthority("ROLE_USER")
+.requestMatchers(HttpMethod.GET, "/api/restaurants/*/reviews/*/edit").hasAuthority("ROLE_USER")
+.requestMatchers(HttpMethod.PUT, "/api/restaurants/*/reviews/*").hasAuthority("ROLE_USER")
+.requestMatchers(HttpMethod.DELETE, "/api/restaurants/*/reviews/*").hasAuthority("ROLE_USER")
+```
+
+### 2) refresh 응답 형식 정합성 수정
+
+- 프론트는 `{ accessToken }` 형태를 기대하므로, 백엔드 응답을 Map으로 통일.
+```java
+// src/main/java/com/example/LunchGo/account/controller/AccountController.java
+@PostMapping("/refresh")
+public ResponseEntity<?> refresh(HttpServletRequest request, HttpServletResponse response) {
+    String newAccessToken = accountHelper.regenerate(request, response);
+    if (newAccessToken == null) {
+        return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+    }
+    Map<String, String> responseBody = Collections.singletonMap("accessToken", newAccessToken);
+    return new ResponseEntity<>(responseBody, HttpStatus.OK);
+}
+```
+
+### 3) 프론트 httpRequest 통일
+
+- 인증 필요 API 호출을 `axios` → `httpRequest`로 통일하여 토큰 자동 부착/리프레시 적용.
+- `httpRequest`에 `patch` 메서드 추가.
+
+예시:
+```js
+// frontend/src/router/httpRequest.js
+patch(url, params, options = {}) {
+  return instance.patch(url, params, generateConfig(options));
+}
+```
+
+```js
+// frontend/src/views/restaurant/id/reviews/WriteReviewPage.vue
+import httpRequest from "@/router/httpRequest";
+
+const response = await httpRequest.post(
+  `/api/restaurants/${restaurantId}/reviews`,
+  payload
+);
+```
+
+### 4) /api/refresh 호출 방식 정합성 수정
+
+- 프론트 refresh 재발급 요청은 POST로 통일.
+```js
+// frontend/src/router/httpRequest.js
+const res = await axios.post('/api/refresh', {}, { withCredentials: true });
+```
+
+---
+
+## 참고: 커밋 대상 변경 파일
+
+- `src/main/java/com/example/LunchGo/common/config/SecurityConfig.java`
+- `src/main/java/com/example/LunchGo/account/controller/AccountController.java`
+- `frontend/src/router/httpRequest.js`
+- `frontend/src/composables/useCafeteriaRecommendation.js`
+- `frontend/src/composables/useBookmarkShare.js`
+- `frontend/src/views/restaurant/id/reviews/WriteReviewPage.vue`
+- `frontend/src/views/restaurant/id/payment/RestaurantPaymentPage.vue`
+- `frontend/src/views/restaurant/id/confirmation/RestaurantConfirmationPage.vue`
+- `frontend/src/views/my-reservations/ReservationCancelView.vue`
+- `frontend/src/components/ui/FavoriteHeart.vue`
+- `frontend/src/views/business/reviews/BusinessReviewsPage.vue`
+- `frontend/src/views/admin/reviews/AdminReviewsPage.vue`
+- `api_specification.csv`
+
+## 참고 파일
+
+- 보안 설정: `src/main/java/com/example/LunchGo/common/config/SecurityConfig.java`
+- JWT/토큰: `src/main/java/com/example/LunchGo/account/helper/JwtFilter.java`, `src/main/java/com/example/LunchGo/common/util/TokenUtils.java`
+- 로그인/갱신: `src/main/java/com/example/LunchGo/account/controller/AccountController.java`
+- 프론트 인증 처리: `frontend/src/router/httpRequest.js`, `frontend/src/router/index.js`
+
+## 결정/주의사항
+
+- `/api/login`, `/api/join/**`, `/api/auth/**`, `/api/sms/**`는 공개 API로 유지
+- `/api/refresh`는 refresh cookie 기반이므로 접근 정책(permitAll 여부)을 명확히 결정
+- 프론트 라우트 권한(meta.roles)와 백엔드 권한 요구사항을 일치시킬 것

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -89,6 +89,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2227,6 +2228,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2296,6 +2298,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -3648,6 +3651,7 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -3708,6 +3712,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3772,6 +3777,7 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -3841,6 +3847,7 @@
       "integrity": "sha512-8u4xqqUeugGNCYwr9ARNtQKTOj4KmYiJAVKXf2CTIivTCR51j96htbMKWDru8H5SaQWpyVgTfOF8Ylyf5pun1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -4027,6 +4034,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4095,6 +4103,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4242,6 +4251,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",

--- a/frontend/src/components/ui/FavoriteHeart.vue
+++ b/frontend/src/components/ui/FavoriteHeart.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue';
 import { Heart } from 'lucide-vue-next';
-import axios from 'axios'; 
+import httpRequest from '@/router/httpRequest';
 
 const props = defineProps<{
   restaurantId: number;
@@ -39,9 +39,9 @@ const toggleFavorite = async () => {
     isActive.value = false;
     
     try {
-      await axios.delete(`/api/bookmark`,{ 
-      data: { userId: props.userId, restaurantId: props.restaurantId }
-    });
+      await httpRequest.delete(`/api/bookmark`,{
+        data: { userId: props.userId, restaurantId: props.restaurantId }
+      });
       
       emit('update:favorite', false);
       emit('remove'); // 부모에게 삭제 알림 (목록에서 제거)
@@ -68,7 +68,7 @@ const toggleFavorite = async () => {
     isActive.value = true;
     
     try {
-      await axios.post('/api/bookmark', {
+      await httpRequest.post('/api/bookmark', {
         userId: props.userId, restaurantId: props.restaurantId 
       });
       

--- a/frontend/src/composables/useBookmarkShare.js
+++ b/frontend/src/composables/useBookmarkShare.js
@@ -1,50 +1,42 @@
-import axios from "axios";
+import httpRequest from "@/router/httpRequest";
 
 export const useBookmarkShare = () => {
   const searchUserByEmail = (email) =>
-    axios.get("/api/bookmark-links/search", { params: { email } });
+    httpRequest.get("/api/bookmark-links/search", { email });
 
   const searchUsersByEmail = (query) =>
-    axios.get("/api/bookmark-links/search/list", { params: { query } });
+    httpRequest.get("/api/bookmark-links/search/list", { query });
 
   const requestLink = (requesterId, receiverId) =>
-    axios.post("/api/bookmark-links", { requesterId, receiverId });
+    httpRequest.post("/api/bookmark-links", { requesterId, receiverId });
 
   const respondLink = (linkId, status) =>
-    axios.patch(`/api/bookmark-links/${linkId}`, { status });
+    httpRequest.patch(`/api/bookmark-links/${linkId}`, { status });
 
   const getSentLinks = (requesterId, status) =>
-    axios.get("/api/bookmark-links/sent", {
-      params: { requesterId, status },
-    });
+    httpRequest.get("/api/bookmark-links/sent", { requesterId, status });
 
   const getReceivedLinks = (receiverId, status) =>
-    axios.get("/api/bookmark-links/received", {
-      params: { receiverId, status },
-    });
+    httpRequest.get("/api/bookmark-links/received", { receiverId, status });
 
   const deleteLink = (requesterId, receiverId) =>
-    axios.delete("/api/bookmark-links", {
+    httpRequest.delete("/api/bookmark-links", {
       params: { requesterId, receiverId },
     });
 
   const toggleBookmarkVisibility = (userId, restaurantId, isPublic) =>
-    axios.patch("/api/bookmark/visibility", { userId, restaurantId, isPublic });
+    httpRequest.patch("/api/bookmark/visibility", { userId, restaurantId, isPublic });
 
   const togglePromotionAgree = (userId, restaurantId, promotionAgree) =>
-    axios.patch("/api/bookmark/promotion", null, {
+    httpRequest.patch("/api/bookmark/promotion", null, {
       params: { userId, restaurantId, promotionAgree },
     });
 
   const getSharedBookmarks = (requesterId, targetUserId) =>
-    axios.get("/api/bookmark/shared", {
-      params: { requesterId, targetUserId },
-    });
+    httpRequest.get("/api/bookmark/shared", { requesterId, targetUserId });
 
   const getMyBookmarks = (userId) =>
-    axios.get("/api/bookmark/list", {
-      params: { userId },
-    });
+    httpRequest.get("/api/bookmark/list", { userId });
 
   return {
     searchUserByEmail,

--- a/frontend/src/composables/useCafeteriaRecommendation.js
+++ b/frontend/src/composables/useCafeteriaRecommendation.js
@@ -1,5 +1,5 @@
 import { ref } from "vue";
-import axios from "axios";
+import httpRequest from "@/router/httpRequest";
 
 const defaultStorageKey = "cafeteriaRecommendations";
 
@@ -54,15 +54,18 @@ export const useCafeteriaRecommendation = ({ userId, storageKey } = {}) => {
   };
 
   const fetchCafeteriaWeekMenus = async (baseDate) => {
-    const response = await axios.get("/api/cafeteria/menus/week", {
-      params: { userId, baseDate },
+    const response = await httpRequest.get("/api/cafeteria/menus/week", {
+      userId,
+      baseDate,
     });
     return response.data;
   };
 
   const fetchCafeteriaRecommendations = async (baseDate, limit = 2) => {
-    const response = await axios.get("/api/cafeteria/recommendations", {
-      params: { userId, baseDate, limit },
+    const response = await httpRequest.get("/api/cafeteria/recommendations", {
+      userId,
+      baseDate,
+      limit,
     });
     storeRecommendations(response.data?.recommendations ?? []);
   };
@@ -87,7 +90,7 @@ export const useCafeteriaRecommendation = ({ userId, storageKey } = {}) => {
     cafeteriaOcrError.value = "";
 
     try {
-      const response = await axios.post("/api/cafeteria/menus/ocr", formData, {
+      const response = await httpRequest.post("/api/cafeteria/menus/ocr", formData, {
         params: { userId, baseDate },
         headers: { "Content-Type": "multipart/form-data" },
       });
@@ -110,7 +113,7 @@ export const useCafeteriaRecommendation = ({ userId, storageKey } = {}) => {
     }
 
     try {
-      await axios.post("/api/cafeteria/menus/confirm", {
+      await httpRequest.post("/api/cafeteria/menus/confirm", {
         userId,
         imageUrl: cafeteriaImageUrl.value,
         rawText: cafeteriaRawText.value,

--- a/frontend/src/router/httpRequest.js
+++ b/frontend/src/router/httpRequest.js
@@ -41,7 +41,7 @@ instance.interceptors.response.use((res) => {
                 return Promise.reject(err);
             }
 
-            const res = await axios.get('/api/refresh', {withCredentials: true});
+            const res = await axios.post('/api/refresh', {}, {withCredentials: true});
 
             const {accessToken} = res.data || {};
             if (!accessToken) throw new Error('토큰 리프레시 에러');
@@ -89,6 +89,9 @@ export default {
     },
     put(url, params, options = {}) {
         return instance.put(url, params, generateConfig(options));
+    },
+    patch(url, params, options = {}) {
+        return instance.patch(url, params, generateConfig(options));
     },
     delete(url, options = {}) {
         return instance.delete(url, generateConfig(options));

--- a/frontend/src/views/admin/reviews/AdminReviewsPage.vue
+++ b/frontend/src/views/admin/reviews/AdminReviewsPage.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, watch, onMounted } from "vue";
-import axios from "axios";
+import httpRequest from "@/router/httpRequest";
 import AdminSidebar from "@/components/ui/AdminSideBar.vue";
 import AdminHeader from "@/components/ui/AdminHeader.vue";
 import Pagination from "@/components/ui/Pagination.vue";
@@ -110,7 +110,7 @@ const allReviews = ref([]);
 
 const loadAdminReviews = async () => {
   try {
-    const response = await axios.get("/api/admin/reviews");
+    const response = await httpRequest.get("/api/admin/reviews");
     const data = response.data?.data ?? response.data;
     const items = Array.isArray(data) ? data : [];
     allReviews.value = items.map((item) => ({
@@ -403,7 +403,7 @@ const submitReportProcess = async (decision) => {
   if (!selectedReview.value) return;
 
   try {
-    const response = await axios.patch(
+    const response = await httpRequest.patch(
       `/api/admin/reviews/${selectedReview.value.id}/blind-requests`,
       {
         decision: decision === "approve" ? "APPROVE" : "REJECT",

--- a/frontend/src/views/business/reviews/BusinessReviewsPage.vue
+++ b/frontend/src/views/business/reviews/BusinessReviewsPage.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted } from "vue";
 import { RouterLink } from "vue-router";
 import axios from "axios";
+import httpRequest from "@/router/httpRequest";
 import {
   Star,
   MessageSquare,
@@ -373,7 +374,7 @@ const addComment = async (reviewId) => {
   if (!review) return;
 
   try {
-    const response = await axios.post(
+    const response = await httpRequest.post(
       `/api/owners/restaurants/${restaurantId.value}/reviews/${reviewId}/comments`,
       { content }
     );
@@ -398,7 +399,7 @@ const deleteComment = async (reviewId, commentId) => {
   if (!review) return;
 
   try {
-    await axios.delete(
+    await httpRequest.delete(
       `/api/owners/restaurants/${restaurantId.value}/reviews/${reviewId}/comments/${commentId}`
     );
     review.comments = review.comments.filter((c) => c.id !== commentId);
@@ -444,7 +445,7 @@ const submitReport = async () => {
       alert("신고 태그를 다시 선택해주세요.");
       return;
     }
-    const response = await axios.post(
+    const response = await httpRequest.post(
       `/api/owners/restaurants/${restaurantId.value}/reviews/${reportReviewId.value}/blind-requests`,
       {
         tagId: tag.id,

--- a/frontend/src/views/my-reservations/ReservationCancelView.vue
+++ b/frontend/src/views/my-reservations/ReservationCancelView.vue
@@ -2,7 +2,7 @@
 import { computed, ref, onMounted } from "vue";
 import { useRoute, useRouter, RouterLink } from "vue-router";
 import { ArrowLeft, Check } from "lucide-vue-next";
-import axios from "axios";
+import httpRequest from "@/router/httpRequest";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 
@@ -47,7 +47,7 @@ const isSummaryLoading = ref(false);
 const fetchReservationSummary = async () => {
   isSummaryLoading.value = true;
   try {
-    const response = await axios.get(`/api/reservations/${reservationId.value}/summary`);
+    const response = await httpRequest.get(`/api/reservations/${reservationId.value}/summary`);
     const data = response?.data || {};
     reservationSummary.value = {
       restaurantName: data.restaurant?.name || "",
@@ -187,7 +187,7 @@ const canSubmit = computed(() => {
 });
 
 async function cancelReservation(id, payload) {
-  const response = await axios.post(`/api/reservations/${id}/cancel`, payload);
+  const response = await httpRequest.post(`/api/reservations/${id}/cancel`, payload);
   return response?.data;
 }
 

--- a/frontend/src/views/restaurant/id/confirmation/RestaurantConfirmationPage.vue
+++ b/frontend/src/views/restaurant/id/confirmation/RestaurantConfirmationPage.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted } from 'vue';
 import { CheckCircle2, MapPin, Calendar, Clock, Users, Download, Share2 } from 'lucide-vue-next'; // Import Lucide icons for Vue
 import { RouterLink, useRoute } from 'vue-router'; // Import Vue RouterLink
-import axios from 'axios';
+import httpRequest from '@/router/httpRequest';
 import Button from '@/components/ui/Button.vue'; // Import custom Button
 import Card from '@/components/ui/Card.vue';
 
@@ -38,7 +38,7 @@ const fetchReservationDetail = async () => {
   errorMessage.value = '';
   try {
     // TODO: 백엔드 스펙 확정 후 엔드포인트/필드 매핑 조정
-    const response = await axios.get(`/api/reservations/${reservationId}/confirmation`);
+    const response = await httpRequest.get(`/api/reservations/${reservationId}/confirmation`);
     const data = response?.data || {};
 
     reservation.value = {
@@ -89,7 +89,7 @@ const completePaymentFromRedirect = async () => {
   }
 
   try {
-    await axios.post('/api/payments/portone/complete', {
+    await httpRequest.post('/api/payments/portone/complete', {
       merchantUid: String(merchantUid),
       impUid: impUid ? String(impUid) : null,
       paidAmount,

--- a/frontend/src/views/restaurant/id/payment/RestaurantPaymentPage.vue
+++ b/frontend/src/views/restaurant/id/payment/RestaurantPaymentPage.vue
@@ -8,7 +8,7 @@ import {
   Building2,
   Check,
 } from "lucide-vue-next";
-import axios from "axios";
+import httpRequest from "@/router/httpRequest";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 
@@ -70,7 +70,7 @@ const fetchBookingSummary = async () => {
       return;
     }
 
-    const res = await axios.get(`/api/reservations/${reservationId.value}/summary`);
+    const res = await httpRequest.get(`/api/reservations/${reservationId.value}/summary`);
     bookingSummary.value.requestNote =
         res.data?.requestNote ?? res.data?.booking?.requestNote ?? "";
   } catch (e) {
@@ -389,7 +389,7 @@ const handlePayment = async () => {
     // (임시 예약 생성/슬롯 락은 다른 담당에서 구현)
 
     const paymentTypeValue = isDepositOnly.value ? "DEPOSIT" : "PREPAID_FOOD";
-    const paymentRes = await axios.post(
+    const paymentRes = await httpRequest.post(
       `/api/reservations/${currentReservationId}/payments`,
       {
         paymentType: paymentTypeValue,
@@ -402,7 +402,7 @@ const handlePayment = async () => {
     const { merchantUid, amount } = paymentRes.data;
 
     try {
-      await axios.post("/api/payments/portone/requested", {
+      await httpRequest.post("/api/payments/portone/requested", {
         merchantUid,
       });
     } catch (requestError) {
@@ -424,7 +424,7 @@ const handlePayment = async () => {
 
     const portoneResult = await Promise.race([paymentPromise, timeoutPromise]);
 
-    await axios.post("/api/payments/portone/complete", {
+    await httpRequest.post("/api/payments/portone/complete", {
       merchantUid,
       impUid:
         portoneResult.imp_uid ||
@@ -452,11 +452,11 @@ const handlePayment = async () => {
 
     try {
       if (message.includes("초과")) {
-        await axios.post(
+        await httpRequest.post(
           `/api/reservations/${reservationId.value}/payments/expire`
         );
       } else {
-        await axios.post("/api/payments/portone/fail", {
+        await httpRequest.post("/api/payments/portone/fail", {
           reservationId: reservationId.value,
           reason: message,
         });

--- a/frontend/src/views/restaurant/id/reviews/WriteReviewPage.vue
+++ b/frontend/src/views/restaurant/id/reviews/WriteReviewPage.vue
@@ -4,7 +4,7 @@ import { useRoute, useRouter } from "vue-router";
 import { ArrowLeft, X, Upload, Plus, Star } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
-import axios from "axios";
+import httpRequest from "@/router/httpRequest";
 
 const route = useRoute();
 const router = useRouter();
@@ -210,7 +210,7 @@ const existingReviews = {
 const loadExistingReview = async () => {
   if (isEditMode.value && reviewId) {
     try {
-      const response = await axios.get(
+      const response = await httpRequest.get(
         `/api/restaurants/${restaurantId}/reviews/${reviewId}/edit`
       );
       const data = response.data;
@@ -371,7 +371,7 @@ const uploadReviewPhotos = async () => {
       const formData = new FormData();
       formData.append("file", photo.file);
 
-      const response = await axios.post(
+      const response = await httpRequest.post(
         "/api/v1/images/upload/reviews",
         formData,
         {
@@ -410,7 +410,7 @@ const submitReview = async () => {
 
   if (isEditMode.value) {
     try {
-      const response = await axios.put(
+      const response = await httpRequest.put(
         `/api/restaurants/${restaurantId}/reviews/${reviewId}`,
         {
           receiptId: receiptId.value,
@@ -428,7 +428,7 @@ const submitReview = async () => {
     }
   } else {
     try {
-      const response = await axios.post(
+      const response = await httpRequest.post(
         `/api/restaurants/${restaurantId}/reviews`,
         {
           userId: DEFAULT_USER_ID,
@@ -501,7 +501,7 @@ const handleReceiptUpload = async (event) => {
   formData.append("file", file);
 
   try {
-    const response = await axios.post("/api/ocr/receipt", formData, {
+    const response = await httpRequest.post("/api/ocr/receipt", formData, {
       params: { reservationId: reservationId.value },
       headers: { "Content-Type": "multipart/form-data" },
     });

--- a/src/main/java/com/example/LunchGo/account/controller/AccountController.java
+++ b/src/main/java/com/example/LunchGo/account/controller/AccountController.java
@@ -118,7 +118,8 @@ public class AccountController {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED); //401
         }
 
-        return new ResponseEntity<>(newAccessToken, HttpStatus.OK);
+        Map<String, String> responseBody = Collections.singletonMap("accessToken", newAccessToken);
+        return new ResponseEntity<>(responseBody, HttpStatus.OK);
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.example.LunchGo.common.util.TokenUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -49,6 +50,55 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                         //각자 권한 걸어주면 됨니다
                         .requestMatchers("/api/join/**", "/api/auth/**", "/api/sms/**", "/api/login").permitAll()
+                        .requestMatchers("/api/refresh").permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/restaurants/*/reviews",
+                                "/api/restaurants/*/reviews/*",
+                                "/api/restaurants/trending"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/payments/portone/webhook").permitAll()
+
+                        .requestMatchers(HttpMethod.POST, "/api/restaurants/*/reviews").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/restaurants/*/reviews/*/edit").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.PUT, "/api/restaurants/*/reviews/*").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.DELETE, "/api/restaurants/*/reviews/*").hasAuthority("ROLE_USER")
+
+                        .requestMatchers(HttpMethod.POST, "/api/v1/images/upload/*").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/v1/images/presign").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.POST, "/api/ocr/receipt").hasAuthority("ROLE_USER")
+
+                        .requestMatchers(HttpMethod.POST, "/api/reservations/*/payments").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.POST, "/api/payments/portone/complete").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.POST, "/api/payments/portone/fail").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.POST, "/api/payments/portone/requested").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.POST, "/api/reservations/*/payments/expire").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/reservations/*/confirmation").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/reservations/*/summary").hasAuthority("ROLE_USER")
+
+                        .requestMatchers(HttpMethod.POST, "/api/cafeteria/menus/ocr").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.POST, "/api/cafeteria/menus/confirm").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/cafeteria/menus/week").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/cafeteria/recommendations").hasAuthority("ROLE_USER")
+
+                        .requestMatchers(HttpMethod.POST, "/api/bookmark-links").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.PATCH, "/api/bookmark-links/*").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/bookmark-links/sent").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/bookmark-links/received").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/bookmark-links/search").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/bookmark-links/search/list").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.DELETE, "/api/bookmark-links").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.PATCH, "/api/bookmark/visibility").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.PATCH, "/api/bookmark/promotion").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/bookmark/shared").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/bookmark/list").hasAuthority("ROLE_USER")
+
+                        .requestMatchers(HttpMethod.POST, "/api/owners/restaurants/*/reviews/*/comments").hasAuthority("ROLE_OWNER")
+                        .requestMatchers(HttpMethod.DELETE, "/api/owners/restaurants/*/reviews/*/comments/*").hasAuthority("ROLE_OWNER")
+                        .requestMatchers(HttpMethod.POST, "/api/owners/restaurants/*/reviews/*/blind-requests").hasAuthority("ROLE_OWNER")
+                        .requestMatchers(HttpMethod.GET, "/api/business/restaurants/*").hasAuthority("ROLE_OWNER")
+
+                        .requestMatchers(HttpMethod.GET, "/api/admin/reviews").hasAuthority("ROLE_ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/admin/reviews/*/blind-requests").hasAuthority("ROLE_ADMIN")
                         .anyRequest().authenticated()
                 )
 


### PR DESCRIPTION
## 📌 작업 내용

  - API 스펙 기준으로 SecurityConfig 권한 매핑 적용(permitAll/ROLE_USER/ROLE_OWNER/ROLE_ADMIN)
  - /api/refresh permitAll 및 응답 형식 {accessToken}로 정합성 확보
  - 인증 필요 프론트 API 호출을 httpRequest로 통일하고 patch 메서드 추가
  - refresh 재발급 호출을 POST로 변경

<img width="558" height="1224" alt="image" src="https://github.com/user-attachments/assets/09b1e9b8-8b71-44d7-a523-6d8296f8ab08" />

<img width="280" height="570" alt="image" src="https://github.com/user-attachments/assets/b1d30a9d-d92c-43c7-bfc8-2762601c1e7f" />

  ## 📁 변경된 파일

  - src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
  - src/main/java/com/example/LunchGo/account/controller/AccountController.java
  - frontend/src/router/httpRequest.js
  - frontend/src/composables/useCafeteriaRecommendation.js
  - frontend/src/composables/useBookmarkShare.js
  - frontend/src/views/restaurant/id/reviews/WriteReviewPage.vue
  - frontend/src/views/restaurant/id/payment/RestaurantPaymentPage.vue
  - frontend/src/views/restaurant/id/confirmation/RestaurantConfirmationPage.vue
  - frontend/src/views/my-reservations/ReservationCancelView.vue
  - frontend/src/components/ui/FavoriteHeart.vue
  - frontend/src/views/business/reviews/BusinessReviewsPage.vue
  - frontend/src/views/admin/reviews/AdminReviewsPage.vue
  - api_specification.csv
  - docs/kwp-security-implementation.md

  ## 공유사항 to 리뷰어

  - 프론트 refresh 재발급은 POST로 통일했고, 서버 응답도 {accessToken} 형식으로 맞췄습니다.
  - permitAll 목록은 api_specification.csv 기준 Any 항목만 반영했습니다.

  ## 🔗 관련 Issue(선택)

  - 없음

  ## ✔️ 체크리스트(선택)

  - 로그인/refresh 동작 확인
  - 마이페이지 정보 수정 시 refresh 401 해결 확인