### PR TITLE
feat(review): 지난 예약 API 연동, 리뷰 작성/수정 흐름 개선, 내 리뷰 목록 API 연동 등

### DIFF
--- a/docs/reservation-history-troubleshooting.md
+++ b/docs/reservation-history-troubleshooting.md
@@ -1,0 +1,209 @@
+# 지난 예약 방문 횟수 트러블슈팅 기록
+
+## 문제 1: 동일 식당 방문 횟수가 모든 카드에 동일하게 표시됨
+
+### 증상
+- 지난 예약 목록에서 같은 식당 방문 카드들이 모두 동일한 `n번째 방문`으로 표시됨
+- `-10일만의 방문`, `-5일만의 방문`처럼 음수 혹은 이상한 간격이 표시됨
+
+### 원인
+- `restaurant_user_stats`의 누적 방문 횟수/마지막 방문일을 그대로 사용해서, 예약 건별 누적값이 아닌 최신 통계값이 모든 카드에 적용됨
+- 예약별 순서를 고려하지 않아 `daysSinceLastVisit` 계산이 부정확하게 표시됨
+
+### 해결
+- MySQL 8.0 윈도우 함수로 예약 목록 쿼리에서 방문 누적/간격을 예약 건별로 계산
+- `COMPLETED` 상태만 누적되도록 `SUM(CASE ...) OVER (...)` 사용
+- 직전 방문일은 `MAX(CASE ...) OVER (... ROWS BETWEEN ... AND 1 PRECEDING)`로 계산
+
+### 해결 과정
+- 통계 테이블(`restaurant_user_stats`)은 사용자/식당 기준 "최신 누적값"만 제공함을 확인
+- 예약 건별 정렬 기준(예약 일시)으로 윈도우 함수를 적용해 각 카드별 방문 정보를 계산
+
+### 적용 파일
+- `src/main/resources/mapper/ReservationHistoryMapper.xml`
+
+### 적용 코드
+```sql
+-- 완료 예약만 누적 방문 횟수로 계산하여 카드마다 다른 방문 차수를 표시한다.
+CASE
+    WHEN r.status = 'COMPLETED' THEN
+        SUM(CASE WHEN r.status = 'COMPLETED' THEN 1 ELSE 0 END) OVER (
+            PARTITION BY r.user_id, res.restaurant_id
+            ORDER BY slot.slot_date, slot.slot_time
+        )
+    ELSE NULL
+END AS visitCount,
+-- 완료 예약 직전의 완료 방문일만 기준으로 간격을 계산한다.
+CASE
+    WHEN r.status = 'COMPLETED' THEN
+        DATEDIFF(
+            slot.slot_date,
+            MAX(CASE WHEN r.status = 'COMPLETED' THEN slot.slot_date END) OVER (
+                PARTITION BY r.user_id, res.restaurant_id
+                ORDER BY slot.slot_date, slot.slot_time
+                ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+            )
+        )
+    ELSE NULL
+END AS daysSinceLastVisit
+```
+
+### 설명
+통계 테이블은 최신 누적치만 제공하므로, 목록 카드용 누적/간격 계산은 쿼리에서 처리한다.
+
+## 문제 2: 동일 예약의 영수증이 중복 생성되어 지난 예약 카드가 중복 노출됨
+
+### 증상
+- 리뷰 수정 화면에서 영수증을 재업로드할 때마다 `receipts`에 신규 레코드가 추가됨
+- `receipts`가 `reservation_id`로 중복되면서 지난 예약 목록에서 동일 예약이 여러 건으로 보임
+
+### 원인
+- OCR 업로드는 항상 `receipts`에 신규 레코드를 생성함
+- `receipts` 테이블에 `reservation_id` 유니크 제약이 없어서 동일 예약에 다중 영수증이 누적됨
+- 지난 예약 조회가 `receipts`를 `reservation_id`로 조인하면서 중복 행이 생성됨
+
+### 해결
+- `receipts.reservation_id`에 유니크 제약 추가 또는 업로드 시 기존 영수증 갱신 방식으로 변경
+- OCR 업로드 시 기존 영수증이 있으면 `confirmed_amount`, `image_url`, `receipt_items`를 교체
+- 지난 예약 조회는 예약당 1건만 선택하도록 최신 영수증 기준으로 조인
+
+### 해결 과정
+- 동일 예약에서 OCR 재업로드 시 `receipts`에 신규 PK가 계속 생성되는 것을 DB에서 확인
+- `reservation_id` 기준 중복이 지난 예약 목록 중복 노출의 직접 원인임을 확인
+
+### 적용 파일
+- `src/main/java/com/example/LunchGo/review/controller/OcrController.java`
+- `src/main/java/com/example/LunchGo/review/service/ReceiptService.java`
+- `src/main/resources/mapper/ReservationHistoryMapper.xml`
+- `src/main/resources/sql/migration_add_receipt_reservation_unique.sql`
+
+### 적용 코드
+```sql
+-- 예약당 최신 영수증만 남기기 위해 중복을 제거한다.
+DELETE r1
+FROM receipts r1
+JOIN receipts r2
+  ON r1.reservation_id = r2.reservation_id
+ AND r1.receipt_id < r2.receipt_id;
+
+-- 예약당 영수증 1건만 유지하도록 유니크 제약을 추가한다.
+ALTER TABLE receipts
+    ADD UNIQUE KEY uk_receipts_reservation (reservation_id);
+```
+
+```java
+// OCR 재업로드 시 기존 영수증을 갱신하고, 항목은 전부 교체한다.
+Receipt saved = receiptRepository.findTopByReservationIdOrderByCreatedAtDesc(reservationId)
+    .map(existing -> {
+        existing.updateConfirmedAmount(receiptDTO.getTotalAmount());
+        existing.updateImageUrl(receiptImageKey);
+        receiptItemRepository.deleteByReceiptId(existing.getReceiptId());
+        return existing;
+    })
+    .orElseGet(() -> receiptRepository.save(
+        new Receipt(reservationId, receiptDTO.getTotalAmount(), receiptImageKey)
+    ));
+```
+
+```sql
+-- 지난 예약 조회는 최신 영수증만 조인하여 중복 카드를 막는다.
+LEFT JOIN (
+    SELECT r1.*
+    FROM receipts r1
+    JOIN (
+        SELECT reservation_id, MAX(receipt_id) AS max_id
+        FROM receipts
+        GROUP BY reservation_id
+    ) r2 ON r2.max_id = r1.receipt_id
+) rc ON rc.reservation_id = r.reservation_id
+```
+
+### 설명
+중복 영수증은 업로드 단계에서 갱신하고, 목록 조회는 최신 1건만 조인한다.
+
+## 문제 3: 리뷰 수정 시 태그 변경이 저장되지 않음
+
+### 증상
+- 리뷰 수정 화면에서 새 태그 선택 후 저장 시 경고 알림만 뜨고 저장이 되지 않음
+- 기존 태그가 그대로 유지되거나, 태그 변경이 DB에 반영되지 않음
+
+### 원인
+- 저장 요청 시점에 `tagIdByName` 매핑이 비어 있는 경우가 있음
+- 선택 태그는 UI에 남아 있지만, `tagIds`가 빈 배열로 전송되어 업데이트가 무시됨
+
+### 해결
+- 저장 직전에 태그 매핑이 비어 있으면 `/api/reviews/tags`를 재호출하여 매핑을 복구
+- 응답이 `{ data: [...] }` 형식이더라도 정상 파싱되도록 보강
+
+### 해결 과정
+- 수정 화면에서 기존 태그를 모두 해제 후 새 태그만 선택하는 시나리오에서 재현
+- `tagIdsForSubmit`이 빈 배열로 전송되는 것을 확인
+
+### 적용 파일
+- `frontend/src/views/restaurant/id/reviews/WriteReviewPage.vue`
+
+### 적용 코드
+```js
+// 저장 직전에 태그 ID 매핑이 비어 있으면 재조회해 복구한다.
+let tagIdsForSubmit = selectedTags.value
+  .map((tag) => tagIdByName.value[tag])
+  .filter((id) => id);
+if (selectedTags.value.length > 0 && tagIdsForSubmit.length === 0) {
+  const refreshedMap = await loadTagMap();
+  tagIdsForSubmit = selectedTags.value
+    .map((tag) => refreshedMap[tag])
+    .filter((id) => id);
+}
+if (selectedTags.value.length > 0 && tagIdsForSubmit.length === 0) {
+  alert("리뷰 태그 정보를 불러오지 못했습니다. 다시 시도해주세요.");
+  return;
+}
+```
+
+### 설명
+태그 변경은 `selectedTags` 기준으로 `tagIds`를 재계산하며, 매핑이 비면 재조회로 복구한다.
+
+## 문제 4: 리뷰 수정에서 새로 추가한 태그가 DB에 저장되지 않음
+
+### 증상
+- 수정 화면에서 기존 태그는 보이지만, 새로 추가한 태그가 저장되지 않음
+- 저장 후에도 DB(`review_tag_maps`)에 새 태그가 반영되지 않음
+
+### 원인
+- `loadTagMap()`으로 전체 태그 매핑을 받아오더라도,
+  `loadExistingReview()`가 `tagIdByName`을 **기존 리뷰 태그만**으로 덮어씀
+- 그 결과 신규 태그의 ID 매핑이 사라져 `tagIds`가 빈 값으로 전송됨
+
+### 해결
+- 기존 리뷰 태그 매핑을 덮어쓰지 않고 **merge**로 보존
+- `loadTagMap()`을 먼저 실행한 뒤 `loadExistingReview()`를 수행하도록 순서 보장
+
+### 해결 과정
+- 수정 화면에서 `tagIdByName` 값이 기존 태그만 남는 것을 확인
+- 저장 요청의 `tagIds`가 신규 태그를 포함하지 않는 것을 확인
+
+### 적용 파일
+- `frontend/src/views/restaurant/id/reviews/WriteReviewPage.vue`
+
+### 적용 코드
+```js
+// 기존 태그 매핑을 덮어쓰지 않고 merge하여 신규 태그도 ID 매핑을 유지한다.
+tagIdByName.value = {
+  ...tagIdByName.value,
+  ...tags.reduce((acc, tag) => {
+    acc[tag.name] = tag.tagId;
+    return acc;
+  }, {}),
+};
+
+// 태그 전체 매핑을 먼저 로드한 뒤 기존 리뷰 데이터를 읽는다.
+onMounted(async () => {
+  setupDragScroll();
+  await loadTagMap();
+  await loadExistingReview();
+  loadReservationSummary();
+});
+```
+
+### 설명
+태그 매핑은 전체 목록을 먼저 읽고, 리뷰 태그는 병합 처리하여 신규 태그도 유지한다.

--- a/frontend/src/components/ui/UsageHistory.vue
+++ b/frontend/src/components/ui/UsageHistory.vue
@@ -10,7 +10,7 @@ import {
   Edit,
   Trash2,
 } from "lucide-vue-next";
-import axios from "axios";
+import httpRequest from "@/router/httpRequest";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 import FavoriteHeart from "@/components/ui/FavoriteHeart.vue";
@@ -99,7 +99,7 @@ const handleEditReview = (reservation) => {
 // 리뷰 삭제 핸들러
 const handleDeleteReview = (reservation) => {
   if (!confirm("리뷰를 삭제하시겠습니까?")) return;
-  axios
+  httpRequest
     .delete(
       `/api/restaurants/${reservation.restaurant.id}/reviews/${reservation.review.id}`
     )

--- a/frontend/src/views/restaurant/id/reviews/reviewId/ReviewDetailPage.vue
+++ b/frontend/src/views/restaurant/id/reviews/reviewId/ReviewDetailPage.vue
@@ -118,6 +118,10 @@ const setupDragScroll = (element) => {
 
 // 이전 단계로 이동
 const goToPreviousStep = () => {
+  if (route.query.from === "my-reservations") {
+    router.replace({ path: "/my-reservations", query: { tab: "past" } });
+    return;
+  }
   router.back();
 };
 

--- a/src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
@@ -56,6 +56,8 @@ public class SecurityConfig {
                                 "/api/restaurants/*/reviews/*",
                                 "/api/restaurants/trending"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/reviews/tags").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/reviews/my").hasAuthority("ROLE_USER")
                         .requestMatchers(HttpMethod.POST, "/api/payments/portone/webhook").permitAll()
 
                         .requestMatchers(HttpMethod.POST, "/api/restaurants/*/reviews").hasAuthority("ROLE_USER")
@@ -111,7 +113,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:8080"));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-type", "X-Requested-With"));
         configuration.setExposedHeaders(List.of("Authorization", "Location"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/example/LunchGo/reservation/controller/ReservationController.java
+++ b/src/main/java/com/example/LunchGo/reservation/controller/ReservationController.java
@@ -2,6 +2,8 @@ package com.example.LunchGo.reservation.controller;
 
 import com.example.LunchGo.reservation.dto.ReservationCreateRequest;
 import com.example.LunchGo.reservation.dto.ReservationCreateResponse;
+import com.example.LunchGo.reservation.dto.ReservationHistoryItem;
+import com.example.LunchGo.reservation.service.ReservationHistoryService;
 import com.example.LunchGo.reservation.service.ReservationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,6 +20,7 @@ import java.util.List;
 public class ReservationController {
 
     private final ReservationService reservationService;
+    private final ReservationHistoryService reservationHistoryService;
 
     @PostMapping
     public ResponseEntity<ReservationCreateResponse> create(@RequestBody ReservationCreateRequest request) {
@@ -39,5 +42,14 @@ public class ReservationController {
     ) {
         List<LocalTime> times = reservationService.slotTimes(restaurantId, slotDate);
         return ResponseEntity.ok(times);
+    }
+
+    @GetMapping("/history")
+    public ResponseEntity<List<ReservationHistoryItem>> history(
+            @RequestParam Long userId,
+            @RequestParam(defaultValue = "past") String type
+    ) {
+        List<ReservationHistoryItem> items = reservationHistoryService.getHistory(userId, type);
+        return ResponseEntity.ok(items);
     }
 }

--- a/src/main/java/com/example/LunchGo/reservation/domain/ReservationStatus.java
+++ b/src/main/java/com/example/LunchGo/reservation/domain/ReservationStatus.java
@@ -6,6 +6,9 @@ public enum ReservationStatus {
     CONFIRMED,
     PREPAID_CONFIRMED,
     EXPIRED,
+    COMPLETED,
+    REFUND_PENDING,
+    REFUNDED,
     NOSHOW,
     CANCELLED
 }

--- a/src/main/java/com/example/LunchGo/reservation/dto/ReservationHistoryItem.java
+++ b/src/main/java/com/example/LunchGo/reservation/dto/ReservationHistoryItem.java
@@ -1,0 +1,60 @@
+package com.example.LunchGo.reservation.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReservationHistoryItem {
+
+    private Long id;
+    private String confirmationNumber;
+    private RestaurantInfo restaurant;
+    private BookingInfo booking;
+    private Integer visitCount;
+    private Integer daysSinceLastVisit;
+    private PaymentInfo payment;
+    private String reservationStatus;
+    private ReviewInfo review;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RestaurantInfo {
+        private Long id;
+        private String name;
+        private String address;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BookingInfo {
+        private LocalDate date;
+        private LocalTime time;
+        private Integer partySize;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PaymentInfo {
+        private Integer amount;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewInfo {
+        private Long id;
+        private Integer rating;
+        private String content;
+        private List<String> tags;
+        private LocalDate createdAt;
+    }
+}

--- a/src/main/java/com/example/LunchGo/reservation/dto/ReservationSummaryResponse.java
+++ b/src/main/java/com/example/LunchGo/reservation/dto/ReservationSummaryResponse.java
@@ -2,6 +2,7 @@ package com.example.LunchGo.reservation.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import java.util.List;
 
 @Getter
 @Builder
@@ -10,6 +11,9 @@ public class ReservationSummaryResponse {
     private BookingInfo booking;
     private PaymentInfo payment;
     private String requestNote;
+    private Integer totalAmount;
+    private Integer visitCount;
+    private List<MenuItem> menuItems;
 
     @Getter
     @Builder
@@ -32,5 +36,14 @@ public class ReservationSummaryResponse {
     public static class PaymentInfo {
         private String type;
         private Integer amount;
+    }
+
+    @Getter
+    @Builder
+    public static class MenuItem {
+        private String name;
+        private Integer quantity;
+        private Integer unitPrice;
+        private Integer lineAmount;
     }
 }

--- a/src/main/java/com/example/LunchGo/reservation/mapper/ReservationHistoryMapper.java
+++ b/src/main/java/com/example/LunchGo/reservation/mapper/ReservationHistoryMapper.java
@@ -1,0 +1,15 @@
+package com.example.LunchGo.reservation.mapper;
+
+import com.example.LunchGo.reservation.mapper.row.ReservationHistoryRow;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ReservationHistoryMapper {
+    List<ReservationHistoryRow> selectReservationHistory(
+        @Param("userId") Long userId,
+        @Param("statuses") List<String> statuses,
+        @Param("orderDirection") String orderDirection
+    );
+}

--- a/src/main/java/com/example/LunchGo/reservation/mapper/ReservationSummaryMapper.java
+++ b/src/main/java/com/example/LunchGo/reservation/mapper/ReservationSummaryMapper.java
@@ -1,0 +1,13 @@
+package com.example.LunchGo.reservation.mapper;
+
+import com.example.LunchGo.reservation.mapper.row.ReservationMenuItemRow;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ReservationSummaryMapper {
+    List<ReservationMenuItemRow> selectReservationMenuItems(@Param("reservationId") Long reservationId);
+
+    Integer selectVisitCount(@Param("restaurantId") Long restaurantId, @Param("userId") Long userId);
+}

--- a/src/main/java/com/example/LunchGo/reservation/mapper/row/ReservationHistoryRow.java
+++ b/src/main/java/com/example/LunchGo/reservation/mapper/row/ReservationHistoryRow.java
@@ -1,0 +1,36 @@
+package com.example.LunchGo.reservation.mapper.row;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReservationHistoryRow {
+
+    private Long reservationId;
+    private String reservationCode;
+
+    private Long restaurantId;
+    private String restaurantName;
+    private String restaurantAddress;
+
+    private LocalDate slotDate;
+    private LocalTime slotTime;
+    private Integer partySize;
+    private String reservationStatus;
+
+    private Integer visitCount;
+    private Integer daysSinceLastVisit;
+
+    private Integer receiptAmount;
+    private Integer paidAmount;
+    private Integer totalAmount;
+
+    private Long reviewId;
+    private Integer reviewRating;
+    private String reviewContent;
+    private LocalDate reviewCreatedAt;
+    private String reviewTags;
+}

--- a/src/main/java/com/example/LunchGo/reservation/mapper/row/ReservationMenuItemRow.java
+++ b/src/main/java/com/example/LunchGo/reservation/mapper/row/ReservationMenuItemRow.java
@@ -1,0 +1,13 @@
+package com.example.LunchGo.reservation.mapper.row;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReservationMenuItemRow {
+    private String name;
+    private Integer quantity;
+    private Integer unitPrice;
+    private Integer lineAmount;
+}

--- a/src/main/java/com/example/LunchGo/reservation/service/ReservationHistoryService.java
+++ b/src/main/java/com/example/LunchGo/reservation/service/ReservationHistoryService.java
@@ -1,0 +1,8 @@
+package com.example.LunchGo.reservation.service;
+
+import com.example.LunchGo.reservation.dto.ReservationHistoryItem;
+import java.util.List;
+
+public interface ReservationHistoryService {
+    List<ReservationHistoryItem> getHistory(Long userId, String type);
+}

--- a/src/main/java/com/example/LunchGo/reservation/service/ReservationHistoryServiceImpl.java
+++ b/src/main/java/com/example/LunchGo/reservation/service/ReservationHistoryServiceImpl.java
@@ -1,0 +1,111 @@
+package com.example.LunchGo.reservation.service;
+
+import com.example.LunchGo.reservation.dto.ReservationHistoryItem;
+import com.example.LunchGo.reservation.mapper.ReservationHistoryMapper;
+import com.example.LunchGo.reservation.mapper.row.ReservationHistoryRow;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationHistoryServiceImpl implements ReservationHistoryService {
+
+    private final ReservationHistoryMapper reservationHistoryMapper;
+
+    @Override
+    public List<ReservationHistoryItem> getHistory(Long userId, String type) {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId is required");
+        }
+
+        String normalized = type == null ? "past" : type.trim().toLowerCase();
+        List<String> statuses = null;
+        String orderDirection = "DESC";
+        if ("past".equals(normalized)) {
+            statuses = Arrays.asList("COMPLETED", "REFUND_PENDING", "REFUNDED");
+            orderDirection = "DESC";
+        } else if ("upcoming".equals(normalized)) {
+            statuses = Arrays.asList("TEMPORARY", "CONFIRMED", "PREPAID_CONFIRMED");
+            orderDirection = "ASC";
+        } else if ("all".equals(normalized)) {
+            statuses = null;
+            orderDirection = "DESC";
+        } else {
+            throw new IllegalArgumentException("type must be past, upcoming, or all");
+        }
+
+        List<ReservationHistoryRow> rows = reservationHistoryMapper.selectReservationHistory(
+            userId,
+            statuses,
+            orderDirection
+        );
+        if (rows == null || rows.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<ReservationHistoryItem> items = new ArrayList<>();
+        for (ReservationHistoryRow row : rows) {
+            ReservationHistoryItem.RestaurantInfo restaurant = new ReservationHistoryItem.RestaurantInfo(
+                row.getRestaurantId(),
+                row.getRestaurantName(),
+                row.getRestaurantAddress()
+            );
+            ReservationHistoryItem.BookingInfo booking = new ReservationHistoryItem.BookingInfo(
+                row.getSlotDate(),
+                row.getSlotTime(),
+                row.getPartySize()
+            );
+
+            Integer amount = resolvePaymentAmount(row);
+            ReservationHistoryItem.PaymentInfo payment = amount == null
+                ? null
+                : new ReservationHistoryItem.PaymentInfo(amount);
+
+            ReservationHistoryItem.ReviewInfo review = null;
+            if (row.getReviewId() != null) {
+                List<String> tags = parseTags(row.getReviewTags());
+                review = new ReservationHistoryItem.ReviewInfo(
+                    row.getReviewId(),
+                    row.getReviewRating(),
+                    row.getReviewContent(),
+                    tags,
+                    row.getReviewCreatedAt()
+                );
+            }
+
+            items.add(new ReservationHistoryItem(
+                row.getReservationId(),
+                row.getReservationCode(),
+                restaurant,
+                booking,
+                row.getVisitCount(),
+                row.getDaysSinceLastVisit(),
+                payment,
+                row.getReservationStatus(),
+                review
+            ));
+        }
+        return items;
+    }
+
+    private Integer resolvePaymentAmount(ReservationHistoryRow row) {
+        if (row.getReceiptAmount() != null) {
+            return row.getReceiptAmount();
+        }
+        if (row.getPaidAmount() != null) {
+            return row.getPaidAmount();
+        }
+        return row.getTotalAmount();
+    }
+
+    private List<String> parseTags(String rawTags) {
+        if (rawTags == null || rawTags.isBlank()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(rawTags.split("\\|\\|"));
+    }
+}

--- a/src/main/java/com/example/LunchGo/review/controller/MyReviewController.java
+++ b/src/main/java/com/example/LunchGo/review/controller/MyReviewController.java
@@ -1,0 +1,27 @@
+package com.example.LunchGo.review.controller;
+
+import com.example.LunchGo.review.dto.MyReviewItem;
+import com.example.LunchGo.review.service.MyReviewService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reviews")
+public class MyReviewController {
+
+    private final MyReviewService myReviewService;
+
+    @GetMapping("/my")
+    public ResponseEntity<List<MyReviewItem>> myReviews(
+        @RequestParam Long userId
+    ) {
+        List<MyReviewItem> response = myReviewService.getMyReviews(userId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/LunchGo/review/controller/ReviewController.java
+++ b/src/main/java/com/example/LunchGo/review/controller/ReviewController.java
@@ -51,6 +51,7 @@ public class ReviewController {
         return ResponseEntity.ok(response);
     }
 
+
     @GetMapping("/{reviewId}")
     public ResponseEntity<ReviewDetailResponse> detail(
         @PathVariable Long restaurantId,

--- a/src/main/java/com/example/LunchGo/review/controller/ReviewTagController.java
+++ b/src/main/java/com/example/LunchGo/review/controller/ReviewTagController.java
@@ -1,0 +1,32 @@
+package com.example.LunchGo.review.controller;
+
+import com.example.LunchGo.review.dto.TagResponse;
+import com.example.LunchGo.review.entity.ReviewTag;
+import com.example.LunchGo.review.repository.ReviewTagRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reviews/tags")
+public class ReviewTagController {
+
+    private final ReviewTagRepository reviewTagRepository;
+
+    @GetMapping
+    public ResponseEntity<List<TagResponse>> list() {
+        List<TagResponse> tags = reviewTagRepository.findAll().stream()
+            .map(this::toResponse)
+            .collect(Collectors.toList());
+        return ResponseEntity.ok(tags);
+    }
+
+    private TagResponse toResponse(ReviewTag tag) {
+        return new TagResponse(tag.getTagId(), tag.getName());
+    }
+}

--- a/src/main/java/com/example/LunchGo/review/dto/MyReviewItem.java
+++ b/src/main/java/com/example/LunchGo/review/dto/MyReviewItem.java
@@ -1,0 +1,30 @@
+package com.example.LunchGo.review.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MyReviewItem {
+    private Long reviewId;
+    private Long reservationId;
+    private RestaurantInfo restaurant;
+    private Integer visitCount;
+    private Integer rating;
+    private LocalDateTime createdAt;
+    private LocalDate visitDate;
+    private String content;
+    private List<String> tags;
+    private List<String> images;
+
+    @Getter
+    @AllArgsConstructor
+    public static class RestaurantInfo {
+        private Long id;
+        private String name;
+        private String address;
+    }
+}

--- a/src/main/java/com/example/LunchGo/review/dto/ReviewEditResponse.java
+++ b/src/main/java/com/example/LunchGo/review/dto/ReviewEditResponse.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 public class ReviewEditResponse {
     private Long reviewId;
     private Long restaurantId;
+    private Long reservationId;
     private Long receiptId;
     private Integer rating;
     private String content;

--- a/src/main/java/com/example/LunchGo/review/dto/UpdateReviewRequest.java
+++ b/src/main/java/com/example/LunchGo/review/dto/UpdateReviewRequest.java
@@ -12,4 +12,13 @@ public class UpdateReviewRequest {
     private String content;
     private List<Long> tagIds;
     private List<String> imageUrls;
+    private List<ReceiptItemRequest> receiptItems;
+
+    @Getter
+    @Setter
+    public static class ReceiptItemRequest {
+        private String name;
+        private Integer quantity;
+        private Integer price;
+    }
 }

--- a/src/main/java/com/example/LunchGo/review/entity/Receipt.java
+++ b/src/main/java/com/example/LunchGo/review/entity/Receipt.java
@@ -40,6 +40,14 @@ public class Receipt {
         this.imageUrl = imageUrl;
     }
 
+    public void updateConfirmedAmount(Integer confirmedAmount) {
+        this.confirmedAmount = confirmedAmount;
+    }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
     @PrePersist
     public void onCreate() {
         if (createdAt == null) {

--- a/src/main/java/com/example/LunchGo/review/entity/Review.java
+++ b/src/main/java/com/example/LunchGo/review/entity/Review.java
@@ -32,6 +32,9 @@ public class Review {
     @Column(name = "receipt_id")
     private Long receiptId;
 
+    @Column(name = "reservation_id")
+    private Long reservationId;
+
     @Column(name = "rating", nullable = false)
     private Integer rating;
 
@@ -56,10 +59,11 @@ public class Review {
     @Column(name = "blind_requested_at")
     private LocalDateTime blindRequestedAt;
 
-    public Review(Long restaurantId, Long userId, Long receiptId, Integer rating, String content) {
+    public Review(Long restaurantId, Long userId, Long receiptId, Long reservationId, Integer rating, String content) {
         this.restaurantId = restaurantId;
         this.userId = userId;
         this.receiptId = receiptId;
+        this.reservationId = reservationId;
         this.rating = rating;
         this.content = content;
     }

--- a/src/main/java/com/example/LunchGo/review/mapper/MyReviewMapper.java
+++ b/src/main/java/com/example/LunchGo/review/mapper/MyReviewMapper.java
@@ -1,0 +1,11 @@
+package com.example.LunchGo.review.mapper;
+
+import com.example.LunchGo.review.mapper.row.MyReviewRow;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface MyReviewMapper {
+    List<MyReviewRow> selectMyReviews(@Param("userId") Long userId);
+}

--- a/src/main/java/com/example/LunchGo/review/mapper/row/MyReviewRow.java
+++ b/src/main/java/com/example/LunchGo/review/mapper/row/MyReviewRow.java
@@ -1,0 +1,23 @@
+package com.example.LunchGo.review.mapper.row;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MyReviewRow {
+    private Long reviewId;
+    private Long reservationId;
+    private Long restaurantId;
+    private String restaurantName;
+    private String restaurantAddress;
+    private Integer visitCount;
+    private Integer rating;
+    private LocalDateTime createdAt;
+    private LocalDate visitDate;
+    private String content;
+    private String tags;
+    private String images;
+}

--- a/src/main/java/com/example/LunchGo/review/repository/ReceiptItemRepository.java
+++ b/src/main/java/com/example/LunchGo/review/repository/ReceiptItemRepository.java
@@ -4,4 +4,5 @@ import com.example.LunchGo.review.entity.ReceiptItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReceiptItemRepository extends JpaRepository<ReceiptItem, Long> {
+    void deleteByReceiptId(Long receiptId);
 }

--- a/src/main/java/com/example/LunchGo/review/repository/ReceiptRepository.java
+++ b/src/main/java/com/example/LunchGo/review/repository/ReceiptRepository.java
@@ -2,6 +2,8 @@ package com.example.LunchGo.review.repository;
 
 import com.example.LunchGo.review.entity.Receipt;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
+    Optional<Receipt> findTopByReservationIdOrderByCreatedAtDesc(Long reservationId);
 }

--- a/src/main/java/com/example/LunchGo/review/service/MyReviewService.java
+++ b/src/main/java/com/example/LunchGo/review/service/MyReviewService.java
@@ -1,0 +1,8 @@
+package com.example.LunchGo.review.service;
+
+import com.example.LunchGo.review.dto.MyReviewItem;
+import java.util.List;
+
+public interface MyReviewService {
+    List<MyReviewItem> getMyReviews(Long userId);
+}

--- a/src/main/java/com/example/LunchGo/review/service/MyReviewServiceImpl.java
+++ b/src/main/java/com/example/LunchGo/review/service/MyReviewServiceImpl.java
@@ -1,0 +1,60 @@
+package com.example.LunchGo.review.service;
+
+import com.example.LunchGo.review.dto.MyReviewItem;
+import com.example.LunchGo.review.mapper.MyReviewMapper;
+import com.example.LunchGo.review.mapper.row.MyReviewRow;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MyReviewServiceImpl implements MyReviewService {
+
+    private final MyReviewMapper myReviewMapper;
+
+    @Override
+    public List<MyReviewItem> getMyReviews(Long userId) {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId is required");
+        }
+
+        List<MyReviewRow> rows = myReviewMapper.selectMyReviews(userId);
+        if (rows == null || rows.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return rows.stream()
+            .map(this::mapRow)
+            .collect(Collectors.toList());
+    }
+
+    private MyReviewItem mapRow(MyReviewRow row) {
+        return new MyReviewItem(
+            row.getReviewId(),
+            row.getReservationId(),
+            new MyReviewItem.RestaurantInfo(
+                row.getRestaurantId(),
+                row.getRestaurantName(),
+                row.getRestaurantAddress()
+            ),
+            row.getVisitCount(),
+            row.getRating(),
+            row.getCreatedAt(),
+            row.getVisitDate(),
+            row.getContent(),
+            splitList(row.getTags()),
+            splitList(row.getImages())
+        );
+    }
+
+    private List<String> splitList(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(raw.split("\\|\\|"));
+    }
+}

--- a/src/main/resources/mapper/MyReviewMapper.xml
+++ b/src/main/resources/mapper/MyReviewMapper.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.LunchGo.review.mapper.MyReviewMapper">
+
+    <select id="selectMyReviews" resultType="com.example.LunchGo.review.mapper.row.MyReviewRow">
+        SELECT
+            r.review_id AS reviewId,
+            r.reservation_id AS reservationId,
+            r.restaurant_id AS restaurantId,
+            res.name AS restaurantName,
+            CONCAT(res.road_address, ' ', res.detail_address) AS restaurantAddress,
+            ROW_NUMBER() OVER (
+                PARTITION BY r.user_id, r.restaurant_id
+                ORDER BY COALESCE(slot.slot_date, DATE(r.created_at)), r.created_at
+            ) AS visitCount,
+            r.rating AS rating,
+            r.created_at AS createdAt,
+            COALESCE(slot.slot_date, DATE(r.created_at)) AS visitDate,
+            r.content AS content,
+            tags.tags AS tags,
+            images.images AS images
+        FROM reviews r
+        JOIN restaurants res ON res.restaurant_id = r.restaurant_id
+        LEFT JOIN reservations rs ON rs.reservation_id = r.reservation_id
+        LEFT JOIN restaurant_reservation_slots slot ON slot.slot_id = rs.slot_id
+        LEFT JOIN (
+            SELECT m.review_id, GROUP_CONCAT(rt.name ORDER BY rt.tag_id SEPARATOR '||') AS tags
+            FROM review_tag_maps m
+            JOIN review_tags rt ON rt.tag_id = m.tag_id
+            GROUP BY m.review_id
+        ) tags ON tags.review_id = r.review_id
+        LEFT JOIN (
+            SELECT review_id, GROUP_CONCAT(image_url ORDER BY sort_order SEPARATOR '||') AS images
+            FROM review_images
+            GROUP BY review_id
+        ) images ON images.review_id = r.review_id
+        WHERE r.user_id = #{userId}
+        ORDER BY r.created_at DESC
+    </select>
+</mapper>

--- a/src/main/resources/mapper/ReservationHistoryMapper.xml
+++ b/src/main/resources/mapper/ReservationHistoryMapper.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.LunchGo.reservation.mapper.ReservationHistoryMapper">
+
+    <select id="selectReservationHistory" resultType="com.example.LunchGo.reservation.mapper.row.ReservationHistoryRow">
+        SELECT
+            r.reservation_id AS reservationId,
+            r.reservation_code AS reservationCode,
+            res.restaurant_id AS restaurantId,
+            res.name AS restaurantName,
+            CONCAT(res.road_address, ' ', res.detail_address) AS restaurantAddress,
+            slot.slot_date AS slotDate,
+            slot.slot_time AS slotTime,
+            r.party_size AS partySize,
+            r.status AS reservationStatus,
+            CASE
+                WHEN r.status = 'COMPLETED' THEN
+                    SUM(CASE WHEN r.status = 'COMPLETED' THEN 1 ELSE 0 END) OVER (
+                        PARTITION BY r.user_id, res.restaurant_id
+                        ORDER BY slot.slot_date, slot.slot_time
+                    )
+                ELSE NULL
+            END AS visitCount,
+            CASE
+                WHEN r.status = 'COMPLETED' THEN
+                    DATEDIFF(
+                        slot.slot_date,
+                        MAX(CASE WHEN r.status = 'COMPLETED' THEN slot.slot_date END) OVER (
+                            PARTITION BY r.user_id, res.restaurant_id
+                            ORDER BY slot.slot_date, slot.slot_time
+                            ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+                        )
+                    )
+                ELSE NULL
+            END AS daysSinceLastVisit,
+            rc.confirmed_amount AS receiptAmount,
+            pay.paid_amount AS paidAmount,
+            r.total_amount AS totalAmount,
+            rv.review_id AS reviewId,
+            rv.rating AS reviewRating,
+            rv.content AS reviewContent,
+            DATE(rv.created_at) AS reviewCreatedAt,
+            GROUP_CONCAT(DISTINCT rt.name ORDER BY rt.tag_id SEPARATOR '||') AS reviewTags
+        FROM reservations r
+        JOIN restaurant_reservation_slots slot ON slot.slot_id = r.slot_id
+        JOIN restaurants res ON res.restaurant_id = slot.restaurant_id
+        LEFT JOIN (
+            SELECT r1.*
+            FROM receipts r1
+            JOIN (
+                SELECT reservation_id, MAX(receipt_id) AS max_id
+                FROM receipts
+                GROUP BY reservation_id
+            ) r2 ON r2.max_id = r1.receipt_id
+        ) rc ON rc.reservation_id = r.reservation_id
+        LEFT JOIN reviews rv ON rv.reservation_id = r.reservation_id
+        LEFT JOIN review_tag_maps rtm ON rtm.review_id = rv.review_id
+        LEFT JOIN review_tags rt ON rt.tag_id = rtm.tag_id
+        LEFT JOIN (
+            SELECT reservation_id, SUM(amount) AS paid_amount
+            FROM payments
+            WHERE status = 'PAID'
+            GROUP BY reservation_id
+        ) pay ON pay.reservation_id = r.reservation_id
+        WHERE r.user_id = #{userId}
+        <if test="statuses != null and statuses.size() &gt; 0">
+            AND r.status IN
+            <foreach collection="statuses" item="status" open="(" separator="," close=")">
+                #{status}
+            </foreach>
+        </if>
+        GROUP BY
+            r.reservation_id,
+            r.reservation_code,
+            res.restaurant_id,
+            res.name,
+            res.road_address,
+            res.detail_address,
+            slot.slot_date,
+            slot.slot_time,
+            r.party_size,
+            r.status,
+            rc.confirmed_amount,
+            pay.paid_amount,
+            r.total_amount,
+            rv.review_id,
+            rv.rating,
+            rv.content,
+            rv.created_at
+        ORDER BY slot.slot_date ${orderDirection}, slot.slot_time ${orderDirection}
+    </select>
+</mapper>

--- a/src/main/resources/mapper/ReservationSummaryMapper.xml
+++ b/src/main/resources/mapper/ReservationSummaryMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.LunchGo.reservation.mapper.ReservationSummaryMapper">
+
+    <select id="selectReservationMenuItems" resultType="com.example.LunchGo.reservation.mapper.row.ReservationMenuItemRow">
+        SELECT
+            menu_name AS name,
+            quantity AS quantity,
+            unit_price AS unitPrice,
+            line_amount AS lineAmount
+        FROM reservation_menu_items
+        WHERE reservation_id = #{reservationId}
+        ORDER BY reservation_menu_item_id ASC
+    </select>
+
+    <select id="selectVisitCount" resultType="int">
+        SELECT visit_cnt
+        FROM restaurant_user_stats
+        WHERE restaurant_id = #{restaurantId}
+          AND user_id = #{userId}
+    </select>
+</mapper>

--- a/src/main/resources/sql/insert_mock_data_reservation.sql
+++ b/src/main/resources/sql/insert_mock_data_reservation.sql
@@ -1,6 +1,15 @@
 use lunchgo;
 
 
+-- 지난 예약 테스트용 슬롯 (user_id=11)
+INSERT IGNORE INTO restaurant_reservation_slots
+    (slot_id, restaurant_id, slot_date, slot_time, max_capacity)
+VALUES
+    (1001, 1, '2025-11-15', '11:00:00', 20),
+    (1002, 1, '2025-11-10', '12:00:00', 20),
+    (1003, 2, '2025-11-16', '19:30:00', 20),
+    (1004, 1, '2025-11-20', '12:30:00', 20);
+
 -- 예약 목데이터
 INSERT INTO reservations
 (reservation_id, reservation_code, slot_id, user_id, party_size, reservation_type, status, request_message,
@@ -23,3 +32,36 @@ VALUES
 
     (6, 'R20251224-0006', 6, 2, 4, 'RESERVATION_DEPOSIT', 'NO_SHOW', NULL,
      NULL, NULL, '2025-12-22 15:00:25', '2025-12-22 15:00:25');
+
+-- 지난 예약 테스트용 예약 (user_id=11)
+INSERT INTO reservations
+    (reservation_id, reservation_code, slot_id, user_id, party_size, reservation_type, status, request_message,
+     deposit_amount, prepay_amount, total_amount, currency,
+     hold_expires_at, payment_deadline_at, created_at, updated_at)
+VALUES
+    (101, 'R20251115-0011', 1001, 11, 4, 'RESERVATION_DEPOSIT', 'COMPLETED', NULL,
+     15000, NULL, 85000, 'KRW',
+     NULL, NULL, '2025-11-15 10:30:00', '2025-11-15 10:30:00'),
+    (102, 'R20251110-0011', 1002, 11, 2, 'RESERVATION_DEPOSIT', 'REFUND_PENDING', NULL,
+     10000, NULL, 42000, 'KRW',
+     NULL, NULL, '2025-11-10 12:00:00', '2025-11-10 12:00:00'),
+    (103, 'R20251116-0011', 1003, 11, 3, 'RESERVATION_DEPOSIT', 'REFUNDED', NULL,
+     12000, NULL, 95000, 'KRW',
+     NULL, NULL, '2025-11-16 19:00:00', '2025-11-16 19:00:00'),
+    (104, 'R20251120-0011', 1004, 11, 2, 'PREORDER_PREPAY', 'COMPLETED', NULL,
+     NULL, 52000, 52000, 'KRW',
+     NULL, NULL, '2025-11-20 12:00:00', '2025-11-20 12:00:00');
+
+-- 선결제 메뉴 샘플 (reservation_id=104)
+INSERT INTO reservation_menu_items
+    (reservation_menu_item_id, reservation_id, menu_id, menu_name, unit_price, quantity, line_amount, created_at)
+VALUES
+    (1041, 104, 1, '돈까스 정식', 16000, 1, 16000, '2025-11-20 12:00:00'),
+    (1042, 104, 2, '김치나베', 12000, 1, 12000, '2025-11-20 12:00:00'),
+    (1043, 104, 3, '우동', 8000, 3, 24000, '2025-11-20 12:00:00');
+
+-- 이용 완료 횟수 통계 (user_id=11)
+INSERT INTO restaurant_user_stats
+    (restaurant_id, user_id, visit_cnt, total_spend_amt, last_visit_date)
+VALUES
+    (1, 11, 2, 137000, '2025-11-20');

--- a/src/main/resources/sql/migration_add_receipt_reservation_unique.sql
+++ b/src/main/resources/sql/migration_add_receipt_reservation_unique.sql
@@ -1,0 +1,30 @@
+USE lunchgo;
+
+UPDATE reviews r
+JOIN (
+    SELECT reservation_id, MAX(receipt_id) AS keep_id
+    FROM receipts
+    GROUP BY reservation_id
+) keep ON keep.reservation_id = (
+    SELECT reservation_id
+    FROM receipts
+    WHERE receipt_id = r.receipt_id
+)
+SET r.receipt_id = keep.keep_id;
+
+DELETE FROM receipts
+WHERE receipt_id IN (
+    SELECT receipt_id FROM (
+        SELECT
+            receipt_id,
+            ROW_NUMBER() OVER (
+                PARTITION BY reservation_id
+                ORDER BY receipt_id DESC
+            ) AS rn
+        FROM receipts
+    ) t
+    WHERE t.rn > 1
+);
+
+ALTER TABLE receipts
+    ADD UNIQUE KEY uk_receipts_reservation (reservation_id);

--- a/src/main/resources/sql/migration_add_review_reservation_id.sql
+++ b/src/main/resources/sql/migration_add_review_reservation_id.sql
@@ -1,0 +1,16 @@
+USE lunchgo;
+
+ALTER TABLE reviews
+    ADD COLUMN reservation_id BIGINT NULL COMMENT '예약 ID';
+
+UPDATE reviews r
+JOIN receipts rc ON rc.receipt_id = r.receipt_id
+SET r.reservation_id = rc.reservation_id
+WHERE r.receipt_id IS NOT NULL
+  AND r.reservation_id IS NULL;
+
+ALTER TABLE reviews
+    ADD INDEX idx_reviews_reservation_id (reservation_id),
+    ADD CONSTRAINT fk_reviews_reservation
+        FOREIGN KEY (reservation_id) REFERENCES reservations(reservation_id)
+        ON DELETE SET NULL;


### PR DESCRIPTION
## 📌 작업 내용
  - 지난 예약/내 리뷰 목록을 DB 연동하도록 API 및 프론트 연동
  - 예약 상태/요약 데이터 확장 및 리뷰-예약 연결, 영수증 중복 방지 로직 추가
  - 리뷰 작성/수정 UX 개선 및 태그/영수증 처리 안정화
  - 즐겨찾기 공유 PATCH CORS 허용 및 트러블슈팅 문서 정리

리뷰 생성, 수정, 삭제 테스트 (프론트 및 백엔드 db 연동) 완료
<img width="371" height="820" alt="스크린샷 2026-01-02 오전 1 22 01" src="https://github.com/user-attachments/assets/ad4eaeb9-e11c-4e24-ae07-e29c91f79861" />

<img width="377" height="813" alt="스크린샷 2026-01-02 오전 12 07 18" src="https://github.com/user-attachments/assets/36963c76-c2f4-413f-9fca-413bf52a80a6" />


  ## 📁 변경된 파일
  - frontend/src/views/my-reservations/MyReservationsPage.vue
  - frontend/src/components/ui/UsageHistory.vue
  - frontend/src/views/restaurant/id/reviews/WriteReviewPage.vue
  - frontend/src/views/restaurant/id/reviews/reviewId/ReviewDetailPage.vue
  - frontend/src/views/mypage/reviews/ReviewsPage.vue
  - src/main/java/com/example/LunchGo/reservation/** (History/Status/Summary/PaymentService)
  - src/main/java/com/example/LunchGo/review/** (Review/Receipt/MyReview/Tag)
  - src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
  - src/main/resources/mapper/** (ReservationHistory/ReservationSummary/MyReview)
  - src/main/resources/sql/** (insert_mock_data_reservation, migrations)
  - docs/reservation-history-troubleshooting.md

  ## ✔️ 체크리스트(선택)
  - [x] 수동 테스트: 지난 예약/리뷰 작성/수정/목록/즐겨찾기 공유 링크 수락