### PR TITLE
feat: 예약 완료 스냅샷/히스토리 쿼리 최적화 및 ui 개선

### DIFF
--- a/docs/reservation-history-query-analysis.md
+++ b/docs/reservation-history-query-analysis.md
@@ -1,0 +1,342 @@
+# 예약 이력 쿼리 분석 및 개선안
+
+## 문제 요약
+현재 `ReservationHistoryMapper.xml`의 조회 쿼리는 `reviews`와 `review_tag_maps`를 조인한 뒤
+윈도우 함수를 계산한다. 이 구조는 **태그 수만큼 중복 행이 생긴 상태에서 방문 횟수/간격이
+계산되는 문제**가 발생할 수 있다. 결과적으로 `visitCount`와 `daysSinceLastVisit` 값이
+실제보다 부풀어질 위험이 있다.
+
+## 문제 발생 원인
+현재 쿼리 구조(요약):
+```sql
+FROM reservations r
+JOIN slots ...
+JOIN restaurants ...
+LEFT JOIN reviews rv ON rv.reservation_id = r.reservation_id
+LEFT JOIN review_tag_maps rtm ON rtm.review_id = rv.review_id
+LEFT JOIN review_tags rt ON rt.tag_id = rtm.tag_id
+...
+SELECT
+  CASE WHEN r.status = 'COMPLETED'
+       THEN SUM(...) OVER (PARTITION BY r.user_id, res.restaurant_id ORDER BY slot.slot_date, slot.slot_time)
+  END AS visitCount,
+  CASE WHEN r.status = 'COMPLETED'
+       THEN DATEDIFF(slot.slot_date, MAX(...) OVER (...))
+  END AS daysSinceLastVisit,
+  GROUP_CONCAT(DISTINCT rt.name ...) AS reviewTags
+```
+
+### 핵심 원인
+- `review_tag_maps` 조인으로 예약 1건이 **태그 개수만큼 복제**된다.
+- 윈도우 함수는 **복제된 행 기준으로 계산**되므로 방문 횟수/간격이 왜곡된다.
+- `GROUP BY`는 윈도우 계산 결과를 다시 줄일 뿐, 계산 과정의 왜곡은 해결하지 못한다.
+
+## 개선 방향
+윈도우 계산을 수행하는 **예약 기본 목록**과 태그 집계를 분리한다.
+즉, 아래 순서로 조회한다:
+
+1) 예약 + 슬롯 + 식당 + 리뷰(기본 정보) + 영수증 + 결제 합산  
+2) 윈도우 함수(`visitCount`, `daysSinceLastVisit`) 계산  
+3) 태그 집계는 별도 서브쿼리에서 `review_id` 기준으로 합쳐서 조인
+
+이렇게 하면 윈도우 계산은 **중복 없는 예약 행** 기준으로 수행된다.
+
+## 개선 예시 (의사 쿼리)
+```sql
+WITH base AS (
+  SELECT
+    r.reservation_id,
+    r.reservation_code,
+    r.user_id,
+    res.restaurant_id,
+    res.name AS restaurantName,
+    CONCAT(res.road_address, ' ', res.detail_address) AS restaurantAddress,
+    slot.slot_date,
+    slot.slot_time,
+    r.party_size,
+    r.status,
+    rc.confirmed_amount,
+    pay.paid_amount,
+    r.total_amount,
+    rv.review_id,
+    rv.rating,
+    rv.content,
+    rv.created_at
+  FROM reservations r
+  JOIN restaurant_reservation_slots slot ON slot.slot_id = r.slot_id
+  JOIN restaurants res ON res.restaurant_id = slot.restaurant_id
+  LEFT JOIN receipts rc ON rc.reservation_id = r.reservation_id
+  LEFT JOIN reviews rv ON rv.reservation_id = r.reservation_id
+  LEFT JOIN (
+    SELECT reservation_id, SUM(amount) AS paid_amount
+    FROM payments
+    WHERE status = 'PAID'
+    GROUP BY reservation_id
+  ) pay ON pay.reservation_id = r.reservation_id
+  WHERE r.user_id = #{userId}
+),
+tags AS (
+  SELECT
+    rtm.review_id,
+    GROUP_CONCAT(rt.name ORDER BY rt.tag_id SEPARATOR '||') AS reviewTags
+  FROM review_tag_maps rtm
+  JOIN review_tags rt ON rt.tag_id = rtm.tag_id
+  GROUP BY rtm.review_id
+)
+SELECT
+  base.*,
+  CASE
+    WHEN base.status = 'COMPLETED' THEN
+      SUM(CASE WHEN base.status = 'COMPLETED' THEN 1 ELSE 0 END) OVER (
+        PARTITION BY base.user_id, base.restaurant_id
+        ORDER BY base.slot_date, base.slot_time
+      )
+  END AS visitCount,
+  CASE
+    WHEN base.status = 'COMPLETED' THEN
+      DATEDIFF(
+        base.slot_date,
+        MAX(CASE WHEN base.status = 'COMPLETED' THEN base.slot_date END) OVER (
+          PARTITION BY base.user_id, base.restaurant_id
+          ORDER BY base.slot_date, base.slot_time
+          ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+        )
+      )
+  END AS daysSinceLastVisit,
+  tags.reviewTags
+FROM base
+LEFT JOIN tags ON tags.review_id = base.review_id
+ORDER BY base.slot_date DESC, base.slot_time DESC;
+```
+
+## 비교 분석 요약
+| 항목 | 기존 쿼리 | 개선 쿼리 |
+| --- | --- | --- |
+| 방문 횟수 계산 | 윈도우 함수로 계산 | 스냅샷 테이블(reservation_visit_stats) 조인 |
+| 태그 집계 | 동일 쿼리 내 GROUP_CONCAT | 동일 (필요 시 분리 가능) |
+| 정확성 | 태그 조인으로 윈도우 결과 왜곡 위험 | 스냅샷 값 사용으로 정확 |
+| 성능 | 윈도우/임시테이블 비용 발생 | 윈도우 제거로 비용 감소 |
+
+## 결론
+현재 쿼리는 **태그 조인으로 인한 행 복제** 때문에 윈도우 계산이 왜곡될 수 있다.
+윈도우 계산을 제거하고 예약 완료 시점에 스냅샷을 저장하면 정확성과 성능을 함께 개선할 수 있다.
+
+## 성능 개선 포인트
+
+- **상관 서브쿼리 제거**: 예약 목록 쿼리 내부에서 반복되는 집계를 파생 테이블로 분리해 1회 집계 후 JOIN.
+- **윈도우 함수 제거**: 방문 정보를 스냅샷 테이블에 저장하고 조회는 조인으로 처리.
+- **집계 재사용**: 태그 집계는 `review_id` 기준으로 1회 수행 후 JOIN(필요 시 분리).
+- **정렬 비용 최소화**: 필요한 정렬 기준(예약일시)만 유지하고, 불필요한 ORDER BY 제거.
+
+## EXPLAIN 비교 템플릿
+
+아래 템플릿에 전/후 실행 계획을 기록한다.
+
+### 성능 비교 방법
+- 동일 파라미터(`userId`, `statuses`)로 전/후 쿼리를 실행한다.
+- MySQL 8.0이라면 `EXPLAIN ANALYZE`를 사용해 실제 실행 시간을 확인한다.
+- 비교 지표는 `rows examined`, `temporary`, `filesort`, `join type`, `execution time` 기준으로 기록한다.
+
+EXPLAIN 요약 비교표
+
+| 항목                   | 전(현재)                               | 후(개선)                               | 개선 포인트                     |
+| ---------------------- | -------------------------------------- | -------------------------------------- | ------------------------------ |
+| 실행 시간(ms)          | 12.2 (Sort actual time)                | 3.14 (Sort actual time)                | 윈도우 제거 효과               |
+| actual time 범위(ms)   | 3.94..12.1 (window max)                | 해당 없음 (윈도우 제거)                | 윈도우 비용 감소               |
+| rows examined          | 131 (group 단계 rows)                  | 131 (group 단계 rows)                  | 스냅샷 조인                    |
+| rows sent              | 124                                    | 124                                    | 동일                           |
+| dependent subquery     | 없음                                   | 없음                                   | -                              |
+| temporary table        | 있음 (윈도우 단계 2회)                 | 없음                                   | 스냅샷으로 윈도우 제거         |
+| filesort               | 있음                                   | 있음                                   | GROUP_CONCAT 정렬 유지         |
+| join type              | Nested Loop                            | Nested Loop                            | 조인 순서 단순화               |
+| 주요 병목              | 태그 조인 후 윈도우 계산/집계           | GROUP_CONCAT 정렬 비용                 | 중복 행/윈도우 제거            |
+
+전(현재 쿼리)
+
+| 항목               | 값 |
+| ------------------ | --- |
+| 실행 시간(ms)      | 12.2 (Sort actual time) |
+| rows examined      | 131 (Stream results rows) |
+| rows sent          | 124 |
+| temporary table    | 있음 (윈도우 단계 2회) |
+| filesort           | 있음 |
+| join type          | Nested Loop |
+| 주요 테이블/인덱스 | reservations(idx_reservation_slot_status), slot(uk_slot), reviews(idx_reviews_reservation_id), review_tag_maps(PRIMARY), review_tags(PRIMARY), receipts(uk_receipts_reservation), payments(idx_payment_status) |
+
+후(개선 쿼리)
+
+| 항목               | 값 |
+| ------------------ | --- |
+| 실행 시간(ms)      | 3.14 (Sort actual time) |
+| rows examined      | 131 (Stream results rows) |
+| rows sent          | 124 |
+| temporary table    | 없음 |
+| filesort           | 있음 |
+| join type          | Nested Loop |
+| 주요 테이블/인덱스 | reservations(idx_reservation_user), reservation_visit_stats(PRIMARY), slot(PRIMARY), reviews(idx_reviews_reservation_id), review_tag_maps(PRIMARY), review_tags(PRIMARY), receipts(uk_receipts_reservation), payments(idx_payment_reservation) |
+
+### EXPLAIN ANALYZE 실행 예시
+```sql
+EXPLAIN ANALYZE
+SELECT
+    r.reservation_id AS reservationId,
+    r.reservation_code AS reservationCode,
+    res.restaurant_id AS restaurantId,
+    res.name AS restaurantName,
+    CONCAT(res.road_address, ' ', res.detail_address) AS restaurantAddress,
+    slot.slot_date AS slotDate,
+    slot.slot_time AS slotTime,
+    r.party_size AS partySize,
+    r.status AS reservationStatus,
+    CASE
+        WHEN r.status = 'COMPLETED' THEN
+            SUM(CASE WHEN r.status = 'COMPLETED' THEN 1 ELSE 0 END) OVER (
+                PARTITION BY r.user_id, res.restaurant_id
+                ORDER BY slot.slot_date, slot.slot_time
+            )
+        ELSE NULL
+    END AS visitCount,
+    CASE
+        WHEN r.status = 'COMPLETED' THEN
+            DATEDIFF(
+                slot.slot_date,
+                MAX(CASE WHEN r.status = 'COMPLETED' THEN slot.slot_date END) OVER (
+                    PARTITION BY r.user_id, res.restaurant_id
+                    ORDER BY slot.slot_date, slot.slot_time
+                    ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+                )
+            )
+        ELSE NULL
+    END AS daysSinceLastVisit,
+    rc.confirmed_amount AS receiptAmount,
+    pay.paid_amount AS paidAmount,
+    r.total_amount AS totalAmount,
+    rv.review_id AS reviewId,
+    rv.rating AS reviewRating,
+    rv.content AS reviewContent,
+    DATE(rv.created_at) AS reviewCreatedAt,
+    GROUP_CONCAT(DISTINCT rt.name ORDER BY rt.tag_id SEPARATOR '||') AS reviewTags
+FROM reservations r
+JOIN restaurant_reservation_slots slot ON slot.slot_id = r.slot_id
+JOIN restaurants res ON res.restaurant_id = slot.restaurant_id
+LEFT JOIN receipts rc ON rc.reservation_id = r.reservation_id
+LEFT JOIN reviews rv ON rv.reservation_id = r.reservation_id
+LEFT JOIN review_tag_maps rtm ON rtm.review_id = rv.review_id
+LEFT JOIN review_tags rt ON rt.tag_id = rtm.tag_id
+LEFT JOIN (
+    SELECT reservation_id, SUM(amount) AS paid_amount
+    FROM payments
+    WHERE status = 'PAID'
+    GROUP BY reservation_id
+) pay ON pay.reservation_id = r.reservation_id
+WHERE r.user_id = 11
+  AND r.status IN ('COMPLETED', 'REFUND_PENDING', 'REFUNDED')
+GROUP BY
+    r.reservation_id,
+    r.reservation_code,
+    res.restaurant_id,
+    res.name,
+    res.road_address,
+    res.detail_address,
+    slot.slot_date,
+    slot.slot_time,
+    r.party_size,
+    r.status,
+    rc.confirmed_amount,
+    pay.paid_amount,
+    r.total_amount,
+    rv.review_id,
+    rv.rating,
+    rv.content,
+    rv.created_at
+ORDER BY slot.slot_date DESC, slot.slot_time DESC;
+```
+
+### 실행 결과(현재 쿼리 요약)
+EXPLAIN ANALYZE 출력에서 확인된 주요 포인트:
+- `Temporary table`와 `filesort`가 존재하며, 윈도우 함수가 `multi-pass aggregate with buffering`으로 실행됨.
+- `review_tag_maps` 조인 이후 `group_concat(distinct ...)`로 집계되며, 그 이전 단계에서 행이 확장됨.
+- 실행 흐름상 `GROUP BY` → `윈도우 함수` 순서로 처리되며, 태그 조인으로 인한 행 증식 후 윈도우 계산이 수행됨.
+
+EXPLAIN ANALYZE 원문 (요약):
+```
+Sort: slot.slot_date DESC, slot.slot_time DESC  (actual time=12.2..12.2 rows=124 loops=1)
+  -> Table scan on <temporary>  (cost=2.5..2.5 rows=0) (actual time=12.1..12.1 rows=124 loops=1)
+    -> Temporary table  (cost=0..0 rows=0) (actual time=12.1..12.1 rows=124 loops=1)
+      -> Window multi-pass aggregate with buffering: max((case when (r.`status` = 'COMPLETED') then slot.slot_date end)) OVER (PARTITION BY r.user_id,res.restaurant_id ORDER BY slot.slot_date,slot.slot_time ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)   (actual time=3.94..12.1 rows=124 loops=1)
+        -> Table scan on <temporary>  (cost=2.5..2.5 rows=0) (actual time=3.93..3.95 rows=124 loops=1)
+          -> Temporary table  (cost=0..0 rows=0) (actual time=3.93..3.93 rows=124 loops=1)
+            -> Window aggregate with buffering: sum((case when (r.`status` = 'COMPLETED') then 1 else 0 end)) OVER (PARTITION BY r.user_id,res.restaurant_id ORDER BY slot.slot_date,slot.slot_time )   (actual time=3.58..3.89 rows=124 loops=1)
+              -> Sort: r.user_id, res.restaurant_id, slot.slot_date, slot.slot_time  (actual time=3.31..3.33 rows=124 loops=1)
+                -> Stream results  (actual time=2.93..3.27 rows=124 loops=1)
+                  -> Group aggregate: group_concat(distinct review_tags.`name` order by review_tags.tag_id ASC separator '||')  (actual time=2.93..3.14 rows=124 loops=1)
+                    -> Sort: r.reservation_id, r.reservation_code, res.restaurant_id, res.`name`, res.road_address, res.detail_address, slot.slot_date, slot.slot_time, r.party_size, r.`status`, rc.confirmed_amount, pay.paid_amount, r.total_amount, rv.review_id, rv.rating, rv.content, rv.created_at  (actual time=2.91..2.94 rows=131 loops=1)
+                      -> Stream results  (cost=2.7e+6 rows=21.4e+6) (actual time=0.288..1.71 rows=131 loops=1)
+                        -> Nested loop left join  (cost=2.7e+6 rows=21.4e+6) (actual time=0.277..1.48 rows=131 loops=1)
+                          -> Nested loop left join  (cost=111204 rows=175501) (actual time=0.0743..1.18 rows=131 loops=1)
+                            -> Nested loop left join  (cost=49779 rows=175501) (actual time=0.0708..1.07 rows=131 loops=1)
+                              -> Nested loop left join  (cost=10506 rows=86546) (actual time=0.0679..0.911 rows=124 loops=1)
+                                -> Nested loop left join  (cost=175 rows=140) (actual time=0.0577..0.626 rows=124 loops=1)
+                                  -> Nested loop inner join  (cost=126 rows=140) (actual time=0.0498..0.416 rows=124 loops=1)
+                                    -> Nested loop inner join  (cost=77.4 rows=140) (actual time=0.0439..0.376 rows=124 loops=1)
+                                      -> Covering index scan on slot using uk_slot  (cost=14.8 rows=145) (actual time=0.0277..0.0409 rows=145 loops=1)
+                                      -> Filter: (r.user_id = 11)  (cost=0.309 rows=0.963) (actual time=0.00193..0.00217 rows=0.855 loops=145)
+                                        -> Index lookup on r using idx_reservation_slot_status (slot_id=slot.slot_id), with index condition: (r.`status` in ('COMPLETED','REFUND_PENDING','REFUNDED'))  (cost=0.309 rows=1.24) (actual time=0.00179..0.00199 rows=0.862 loops=145)
+                                    -> Single-row index lookup on res using PRIMARY (restaurant_id=slot.restaurant_id)  (cost=0.251 rows=1) (actual time=147e-6..174e-6 rows=1 loops=124)
+                                  -> Single-row index lookup on rc using uk_receipts_reservation (reservation_id=r.reservation_id)  (cost=0.251 rows=1) (actual time=0.00152..0.00155 rows=0.984 loops=124)
+                                -> Index lookup on rv using idx_reviews_reservation_id (reservation_id=r.reservation_id)  (cost=12.4 rows=620) (actual time=0.00192..0.00214 rows=0.984 loops=124)
+                              -> Covering index lookup on rtm using PRIMARY (review_id=rv.review_id)  (cost=0.251 rows=2.03) (actual time=798e-6..0.00113 rows=1.04 loops=124)
+                            -> Single-row index lookup on rt using PRIMARY (tag_id=rtm.tag_id)  (cost=0.25 rows=1) (actual time=691e-6..718e-6 rows=0.985 loops=131)
+                          -> Index lookup on pay using <auto_key0> (reservation_id=r.reservation_id)  (cost=37.1..39.4 rows=10.2) (actual time=0.00192..0.00206 rows=0.954 loops=131)
+                            -> Materialize  (cost=36.9..36.9 rows=122) (actual time=0.2..0.2 rows=122 loops=1)
+                              -> Group aggregate: sum(payments.amount)  (cost=24.7 rows=122) (actual time=0.0194..0.164 rows=122 loops=1)
+                                -> Filter: (payments.`status` = 'PAID')  (cost=12.5 rows=122) (actual time=0.016..0.147 rows=122 loops=1)
+                                  -> Index scan on payments using idx_payment_reservation  (cost=12.5 rows=122) (actual time=0.0155..0.135 rows=122 loops=1)
+```
+
+### 해석
+- 태그 조인으로 인해 행이 늘어난 상태에서 윈도우 함수가 계산되어 `visitCount/daysSinceLastVisit`가 왜곡될 수 있다.
+- `Temporary table`이 두 번 생성되며, 윈도우 계산용 정렬 비용이 발생한다.
+- 개선 쿼리는 태그 집계를 분리하여 윈도우 계산 대상 행 수를 줄이는 방향이 적합하다.
+
+### 실행 결과(개선 쿼리 요약)
+EXPLAIN ANALYZE 출력에서 확인된 주요 포인트:
+- `reservation_visit_stats` 조인으로 윈도우 함수를 제거해 `temporary table`이 사라짐.
+- `idx_reservation_user` 기반으로 예약을 먼저 좁혀서 조인 범위를 줄임.
+- `GROUP_CONCAT` 정렬로 인한 `filesort`는 유지됨.
+
+EXPLAIN ANALYZE 원문 (요약 자리):
+```
+Sort: slot.slot_date DESC, slot.slot_time DESC  (actual time=3.12..3.14 rows=124 loops=1)
+  -> Stream results  (actual time=2.78..3.08 rows=124 loops=1)
+    -> Group aggregate: group_concat(distinct review_tags.`name` order by review_tags.tag_id ASC separator '||')  (actual time=2.77..2.96 rows=124 loops=1)
+      -> Sort: r.reservation_id, r.reservation_code, res.restaurant_id, res.`name`, res.road_address, res.detail_address, slot.slot_date, slot.slot_time, r.party_size, r.`status`, rvs.visit_number, rvs.days_since_last_visit, rc.confirmed_amount, pay.paid_amount, r.total_amount, rv.review_id, rv.rating, rv.content, rv.created_at  (actual time=2.75..2.78 rows=131 loops=1)
+        -> Stream results  (cost=2.23e+6 rows=17.7e+6) (actual time=0.235..1.55 rows=131 loops=1)
+          -> Nested loop left join  (cost=2.23e+6 rows=17.7e+6) (actual time=0.226..1.37 rows=131 loops=1)
+            -> Nested loop left join  (cost=91735 rows=144840) (actual time=0.0683..1.12 rows=131 loops=1)
+              -> Nested loop left join  (cost=41041 rows=144840) (actual time=0.0649..1.02 rows=131 loops=1)
+                -> Nested loop left join  (cost=8629 rows=71426) (actual time=0.0597..0.858 rows=124 loops=1)
+                  -> Nested loop inner join  (cost=167 rows=110) (actual time=0.05..0.61 rows=124 loops=1)
+                    -> Nested loop inner join  (cost=129 rows=110) (actual time=0.0457..0.571 rows=124 loops=1)
+                      -> Nested loop left join  (cost=90.2 rows=110) (actual time=0.0425..0.46 rows=124 loops=1)
+                        -> Nested loop left join  (cost=51.7 rows=110) (actual time=0.0384..0.332 rows=124 loops=1)
+                          -> Filter: (r.`status` in ('COMPLETED','REFUND_PENDING','REFUNDED'))  (cost=13.2 rows=110) (actual time=0.0309..0.14 rows=124 loops=1)
+                            -> Index lookup on r using idx_reservation_user (user_id=11)  (cost=13.2 rows=124) (actual time=0.0294..0.112 rows=124 loops=1)
+                          -> Single-row index lookup on rc using uk_receipts_reservation (reservation_id=r.reservation_id)  (cost=0.251 rows=1) (actual time=0.00137..0.0014 rows=0.984 loops=124)
+                        -> Single-row index lookup on rvs using PRIMARY (reservation_id=r.reservation_id)  (cost=0.251 rows=1) (actual time=860e-6..886e-6 rows=0.984 loops=124)
+                      -> Single-row index lookup on slot using PRIMARY (slot_id=r.slot_id)  (cost=0.251 rows=1) (actual time=726e-6..753e-6 rows=1 loops=124)
+                    -> Single-row index lookup on res using PRIMARY (restaurant_id=slot.restaurant_id)  (cost=0.251 rows=1) (actual time=139e-6..166e-6 rows=1 loops=124)
+                  -> Index lookup on rv using idx_reviews_reservation_id (reservation_id=r.reservation_id)  (cost=12.6 rows=650) (actual time=0.00163..0.00185 rows=0.984 loops=124)
+                -> Covering index lookup on rtm using PRIMARY (review_id=rv.review_id)  (cost=0.251 rows=2.03) (actual time=787e-6..0.00113 rows=1.04 loops=124)
+              -> Single-row index lookup on rt using PRIMARY (tag_id=rtm.tag_id)  (cost=0.25 rows=1) (actual time=594e-6..621e-6 rows=0.985 loops=131)
+            -> Index lookup on pay using <auto_key0> (reservation_id=r.reservation_id)  (cost=37.1..39.4 rows=10.2) (actual time=0.00156..0.00171 rows=0.954 loops=131)
+              -> Materialize  (cost=36.9..36.9 rows=122) (actual time=0.154..0.154 rows=122 loops=1)
+                -> Group aggregate: sum(payments.amount)  (cost=24.7 rows=122) (actual time=0.019..0.118 rows=122 loops=1)
+                  -> Filter: (payments.`status` = 'PAID')  (cost=12.5 rows=122) (actual time=0.0151..0.1 rows=122 loops=1)
+                    -> Index scan on payments using idx_payment_reservation  (cost=12.5 rows=122) (actual time=0.0142..0.0875 rows=122 loops=1)
+```
+
+### 분석 코멘트(개선 쿼리)
+- 윈도우 함수가 제거되면서 `temporary table` 생성 비용이 사라져 전체 실행 시간이 크게 단축되었다.
+- `reservation_visit_stats`는 PK 조인이라 비용이 낮고, `idx_reservation_user`로 먼저 필터링되어 드라이빙 테이블 선택이 안정적이다.
+- 여전히 `GROUP_CONCAT`가 정렬을 요구하므로 `filesort`는 남아 있다. 태그를 상세 페이지에서만 필요로 한다면 별도 API로 분리하는 것도 고려할 수 있다.

--- a/src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/ocr/receipt").hasAuthority("ROLE_USER")
 
                         .requestMatchers(HttpMethod.POST, "/api/reservations/*/payments").hasAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.PATCH, "/api/reservations/*/complete").hasAuthority("ROLE_OWNER")
                         .requestMatchers(HttpMethod.POST, "/api/payments/portone/complete").hasAuthority("ROLE_USER")
                         .requestMatchers(HttpMethod.POST, "/api/payments/portone/fail").hasAuthority("ROLE_USER")
                         .requestMatchers(HttpMethod.POST, "/api/payments/portone/requested").hasAuthority("ROLE_USER")

--- a/src/main/java/com/example/LunchGo/reservation/controller/ReservationController.java
+++ b/src/main/java/com/example/LunchGo/reservation/controller/ReservationController.java
@@ -3,6 +3,7 @@ package com.example.LunchGo.reservation.controller;
 import com.example.LunchGo.reservation.dto.ReservationCreateRequest;
 import com.example.LunchGo.reservation.dto.ReservationCreateResponse;
 import com.example.LunchGo.reservation.dto.ReservationHistoryItem;
+import com.example.LunchGo.reservation.service.ReservationCompletionService;
 import com.example.LunchGo.reservation.service.ReservationHistoryService;
 import com.example.LunchGo.reservation.service.ReservationService;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class ReservationController {
 
     private final ReservationService reservationService;
     private final ReservationHistoryService reservationHistoryService;
+    private final ReservationCompletionService reservationCompletionService;
 
     @PostMapping
     public ResponseEntity<ReservationCreateResponse> create(@RequestBody ReservationCreateRequest request) {
@@ -51,5 +53,11 @@ public class ReservationController {
     ) {
         List<ReservationHistoryItem> items = reservationHistoryService.getHistory(userId, type);
         return ResponseEntity.ok(items);
+    }
+
+    @PatchMapping("/{reservationId}/complete")
+    public ResponseEntity<Void> complete(@PathVariable Long reservationId) {
+        reservationCompletionService.complete(reservationId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/LunchGo/reservation/mapper/ReservationVisitStatsMapper.java
+++ b/src/main/java/com/example/LunchGo/reservation/mapper/ReservationVisitStatsMapper.java
@@ -1,0 +1,31 @@
+package com.example.LunchGo.reservation.mapper;
+
+import com.example.LunchGo.reservation.mapper.row.RestaurantUserStatsRow;
+import java.time.LocalDate;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ReservationVisitStatsMapper {
+
+    RestaurantUserStatsRow selectRestaurantUserStatsForUpdate(
+        @Param("restaurantId") Long restaurantId,
+        @Param("userId") Long userId
+    );
+
+    int upsertRestaurantUserStats(
+        @Param("restaurantId") Long restaurantId,
+        @Param("userId") Long userId,
+        @Param("visitCount") Integer visitCount,
+        @Param("lastVisitDate") LocalDate lastVisitDate
+    );
+
+    int insertReservationVisitStats(
+        @Param("reservationId") Long reservationId,
+        @Param("userId") Long userId,
+        @Param("restaurantId") Long restaurantId,
+        @Param("visitNumber") Integer visitNumber,
+        @Param("prevVisitDate") LocalDate prevVisitDate,
+        @Param("daysSinceLastVisit") Integer daysSinceLastVisit
+    );
+}

--- a/src/main/java/com/example/LunchGo/reservation/mapper/row/RestaurantUserStatsRow.java
+++ b/src/main/java/com/example/LunchGo/reservation/mapper/row/RestaurantUserStatsRow.java
@@ -1,0 +1,12 @@
+package com.example.LunchGo.reservation.mapper.row;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RestaurantUserStatsRow {
+    private Integer visitCount;
+    private LocalDate lastVisitDate;
+}

--- a/src/main/java/com/example/LunchGo/reservation/service/ReservationCompletionService.java
+++ b/src/main/java/com/example/LunchGo/reservation/service/ReservationCompletionService.java
@@ -1,0 +1,73 @@
+package com.example.LunchGo.reservation.service;
+
+import com.example.LunchGo.reservation.domain.ReservationStatus;
+import com.example.LunchGo.reservation.entity.Reservation;
+import com.example.LunchGo.reservation.entity.ReservationSlot;
+import com.example.LunchGo.reservation.mapper.ReservationVisitStatsMapper;
+import com.example.LunchGo.reservation.mapper.row.RestaurantUserStatsRow;
+import com.example.LunchGo.reservation.repository.ReservationRepository;
+import com.example.LunchGo.reservation.repository.ReservationSlotRepository;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationCompletionService {
+
+    private final ReservationRepository reservationRepository;
+    private final ReservationSlotRepository reservationSlotRepository;
+    private final ReservationVisitStatsMapper reservationVisitStatsMapper;
+
+    @Transactional
+    public void complete(Long reservationId) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+            .orElseThrow(() -> new IllegalArgumentException("예약 정보를 찾을 수 없습니다."));
+
+        if (ReservationStatus.COMPLETED.equals(reservation.getStatus())) {
+            return;
+        }
+
+        ReservationSlot slot = reservationSlotRepository.findById(reservation.getSlotId())
+            .orElseThrow(() -> new IllegalArgumentException("예약 슬롯 정보를 찾을 수 없습니다."));
+
+        Long userId = reservation.getUserId();
+        Long restaurantId = slot.getRestaurantId();
+        LocalDate slotDate = slot.getSlotDate();
+
+        RestaurantUserStatsRow stats = reservationVisitStatsMapper.selectRestaurantUserStatsForUpdate(
+            restaurantId,
+            userId
+        );
+
+        int currentVisitCount = stats != null && stats.getVisitCount() != null
+            ? stats.getVisitCount()
+            : 0;
+        LocalDate prevVisitDate = stats != null ? stats.getLastVisitDate() : null;
+
+        int visitNumber = currentVisitCount + 1;
+        Integer daysSinceLastVisit = prevVisitDate == null
+            ? null
+            : Math.toIntExact(ChronoUnit.DAYS.between(prevVisitDate, slotDate));
+
+        reservationVisitStatsMapper.insertReservationVisitStats(
+            reservationId,
+            userId,
+            restaurantId,
+            visitNumber,
+            prevVisitDate,
+            daysSinceLastVisit
+        );
+
+        reservationVisitStatsMapper.upsertRestaurantUserStats(
+            restaurantId,
+            userId,
+            visitNumber,
+            slotDate
+        );
+
+        reservation.setStatus(ReservationStatus.COMPLETED);
+    }
+}

--- a/src/main/resources/mapper/ReservationHistoryMapper.xml
+++ b/src/main/resources/mapper/ReservationHistoryMapper.xml
@@ -16,23 +16,11 @@
             r.party_size AS partySize,
             r.status AS reservationStatus,
             CASE
-                WHEN r.status = 'COMPLETED' THEN
-                    SUM(CASE WHEN r.status = 'COMPLETED' THEN 1 ELSE 0 END) OVER (
-                        PARTITION BY r.user_id, res.restaurant_id
-                        ORDER BY slot.slot_date, slot.slot_time
-                    )
+                WHEN r.status = 'COMPLETED' THEN rvs.visit_number
                 ELSE NULL
             END AS visitCount,
             CASE
-                WHEN r.status = 'COMPLETED' THEN
-                    DATEDIFF(
-                        slot.slot_date,
-                        MAX(CASE WHEN r.status = 'COMPLETED' THEN slot.slot_date END) OVER (
-                            PARTITION BY r.user_id, res.restaurant_id
-                            ORDER BY slot.slot_date, slot.slot_time
-                            ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
-                        )
-                    )
+                WHEN r.status = 'COMPLETED' THEN rvs.days_since_last_visit
                 ELSE NULL
             END AS daysSinceLastVisit,
             rc.confirmed_amount AS receiptAmount,
@@ -55,6 +43,7 @@
                 GROUP BY reservation_id
             ) r2 ON r2.max_id = r1.receipt_id
         ) rc ON rc.reservation_id = r.reservation_id
+        LEFT JOIN reservation_visit_stats rvs ON rvs.reservation_id = r.reservation_id
         LEFT JOIN reviews rv ON rv.reservation_id = r.reservation_id
         LEFT JOIN review_tag_maps rtm ON rtm.review_id = rv.review_id
         LEFT JOIN review_tags rt ON rt.tag_id = rtm.tag_id
@@ -82,6 +71,8 @@
             slot.slot_time,
             r.party_size,
             r.status,
+            rvs.visit_number,
+            rvs.days_since_last_visit,
             rc.confirmed_amount,
             pay.paid_amount,
             r.total_amount,

--- a/src/main/resources/mapper/ReservationVisitStatsMapper.xml
+++ b/src/main/resources/mapper/ReservationVisitStatsMapper.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.LunchGo.reservation.mapper.ReservationVisitStatsMapper">
+
+    <select id="selectRestaurantUserStatsForUpdate"
+            resultType="com.example.LunchGo.reservation.mapper.row.RestaurantUserStatsRow">
+        SELECT
+            visit_cnt AS visitCount,
+            last_visit_date AS lastVisitDate
+        FROM restaurant_user_stats
+        WHERE restaurant_id = #{restaurantId}
+          AND user_id = #{userId}
+        FOR UPDATE
+    </select>
+
+    <insert id="upsertRestaurantUserStats">
+        INSERT INTO restaurant_user_stats (
+            restaurant_id,
+            user_id,
+            visit_cnt,
+            last_visit_date
+        ) VALUES (
+            #{restaurantId},
+            #{userId},
+            #{visitCount},
+            #{lastVisitDate}
+        )
+        ON DUPLICATE KEY UPDATE
+            visit_cnt = VALUES(visit_cnt),
+            last_visit_date = VALUES(last_visit_date)
+    </insert>
+
+    <insert id="insertReservationVisitStats">
+        INSERT INTO reservation_visit_stats (
+            reservation_id,
+            user_id,
+            restaurant_id,
+            visit_number,
+            prev_visit_date,
+            days_since_last_visit
+        ) VALUES (
+            #{reservationId},
+            #{userId},
+            #{restaurantId},
+            #{visitNumber},
+            #{prevVisitDate},
+            #{daysSinceLastVisit}
+        )
+    </insert>
+</mapper>

--- a/src/main/resources/sql/migration_add_reservation_visit_stats.sql
+++ b/src/main/resources/sql/migration_add_reservation_visit_stats.sql
@@ -1,0 +1,82 @@
+USE lunchgo;
+
+CREATE TABLE IF NOT EXISTS reservation_visit_stats (
+    reservation_id BIGINT NOT NULL COMMENT '예약 ID (PK)',
+    user_id BIGINT NOT NULL COMMENT '유저 ID',
+    restaurant_id BIGINT NOT NULL COMMENT '식당 ID',
+    visit_number INT NOT NULL COMMENT '해당 예약의 n번째 방문',
+    prev_visit_date DATE NULL COMMENT '직전 방문일',
+    days_since_last_visit INT NULL COMMENT '직전 방문과의 일수',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '스냅샷 생성 시각',
+    PRIMARY KEY (reservation_id),
+    KEY idx_rvs_user_restaurant (user_id, restaurant_id),
+    CONSTRAINT fk_rvs_reservation
+        FOREIGN KEY (reservation_id) REFERENCES reservations(reservation_id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='예약별 방문 스냅샷';
+
+-- ----------------------------------------------------------------------
+-- Backfill: 기존 COMPLETED 예약에 방문 스냅샷 생성
+-- ----------------------------------------------------------------------
+INSERT INTO reservation_visit_stats (
+    reservation_id,
+    user_id,
+    restaurant_id,
+    visit_number,
+    prev_visit_date,
+    days_since_last_visit
+)
+SELECT
+    c.reservation_id,
+    c.user_id,
+    c.restaurant_id,
+    c.visit_number,
+    c.prev_visit_date,
+    CASE
+        WHEN c.prev_visit_date IS NULL THEN NULL
+        ELSE DATEDIFF(c.slot_date, c.prev_visit_date)
+    END AS days_since_last_visit
+FROM (
+    SELECT
+        r.reservation_id,
+        r.user_id,
+        slot.restaurant_id,
+        slot.slot_date,
+        slot.slot_time,
+        ROW_NUMBER() OVER (
+            PARTITION BY r.user_id, slot.restaurant_id
+            ORDER BY slot.slot_date, slot.slot_time
+        ) AS visit_number,
+        LAG(slot.slot_date) OVER (
+            PARTITION BY r.user_id, slot.restaurant_id
+            ORDER BY slot.slot_date, slot.slot_time
+        ) AS prev_visit_date
+    FROM reservations r
+    JOIN restaurant_reservation_slots slot ON slot.slot_id = r.slot_id
+    WHERE r.status = 'COMPLETED'
+) c
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM reservation_visit_stats rvs
+    WHERE rvs.reservation_id = c.reservation_id
+);
+
+-- (선택) restaurant_user_stats를 COMPLETED 기준으로 맞춘다.
+INSERT INTO restaurant_user_stats (
+    restaurant_id,
+    user_id,
+    visit_cnt,
+    last_visit_date
+)
+SELECT
+    slot.restaurant_id,
+    r.user_id,
+    COUNT(*) AS visit_cnt,
+    MAX(slot.slot_date) AS last_visit_date
+FROM reservations r
+JOIN restaurant_reservation_slots slot ON slot.slot_id = r.slot_id
+WHERE r.status = 'COMPLETED'
+GROUP BY slot.restaurant_id, r.user_id
+ON DUPLICATE KEY UPDATE
+    visit_cnt = VALUES(visit_cnt),
+    last_visit_date = VALUES(last_visit_date);

--- a/src/main/resources/sql/reservation_history_query_explain_analyze.sql
+++ b/src/main/resources/sql/reservation_history_query_explain_analyze.sql
@@ -1,0 +1,144 @@
+-- EXPLAIN ANALYZE (current query)
+-- userId/status 값을 테스트 환경에 맞게 변경해서 실행한다.
+-- 예시: userId=11, status IN ('COMPLETED','REFUND_PENDING','REFUNDED')
+EXPLAIN ANALYZE
+SELECT
+    r.reservation_id AS reservationId,
+    r.reservation_code AS reservationCode,
+    res.restaurant_id AS restaurantId,
+    res.name AS restaurantName,
+    CONCAT(res.road_address, ' ', res.detail_address) AS restaurantAddress,
+    slot.slot_date AS slotDate,
+    slot.slot_time AS slotTime,
+    r.party_size AS partySize,
+    r.status AS reservationStatus,
+    CASE
+        WHEN r.status = 'COMPLETED' THEN
+            SUM(CASE WHEN r.status = 'COMPLETED' THEN 1 ELSE 0 END) OVER (
+                PARTITION BY r.user_id, res.restaurant_id
+                ORDER BY slot.slot_date, slot.slot_time
+            )
+        ELSE NULL
+    END AS visitCount,
+    CASE
+        WHEN r.status = 'COMPLETED' THEN
+            DATEDIFF(
+                slot.slot_date,
+                MAX(CASE WHEN r.status = 'COMPLETED' THEN slot.slot_date END) OVER (
+                    PARTITION BY r.user_id, res.restaurant_id
+                    ORDER BY slot.slot_date, slot.slot_time
+                    ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+                )
+            )
+        ELSE NULL
+    END AS daysSinceLastVisit,
+    rc.confirmed_amount AS receiptAmount,
+    pay.paid_amount AS paidAmount,
+    r.total_amount AS totalAmount,
+    rv.review_id AS reviewId,
+    rv.rating AS reviewRating,
+    rv.content AS reviewContent,
+    DATE(rv.created_at) AS reviewCreatedAt,
+    GROUP_CONCAT(DISTINCT rt.name ORDER BY rt.tag_id SEPARATOR '||') AS reviewTags
+FROM reservations r
+JOIN restaurant_reservation_slots slot ON slot.slot_id = r.slot_id
+JOIN restaurants res ON res.restaurant_id = slot.restaurant_id
+LEFT JOIN receipts rc ON rc.reservation_id = r.reservation_id
+LEFT JOIN reviews rv ON rv.reservation_id = r.reservation_id
+LEFT JOIN review_tag_maps rtm ON rtm.review_id = rv.review_id
+LEFT JOIN review_tags rt ON rt.tag_id = rtm.tag_id
+LEFT JOIN (
+    SELECT reservation_id, SUM(amount) AS paid_amount
+    FROM payments
+    WHERE status = 'PAID'
+    GROUP BY reservation_id
+) pay ON pay.reservation_id = r.reservation_id
+WHERE r.user_id = 11
+  AND r.status IN ('COMPLETED', 'REFUND_PENDING', 'REFUNDED')
+GROUP BY
+    r.reservation_id,
+    r.reservation_code,
+    res.restaurant_id,
+    res.name,
+    res.road_address,
+    res.detail_address,
+    slot.slot_date,
+    slot.slot_time,
+    r.party_size,
+    r.status,
+    rc.confirmed_amount,
+    pay.paid_amount,
+    r.total_amount,
+    rv.review_id,
+    rv.rating,
+    rv.content,
+    rv.created_at
+ORDER BY slot.slot_date DESC, slot.slot_time DESC;
+
+-- EXPLAIN ANALYZE (optimized query)
+-- 동일한 userId/status 조건으로 전/후 비교한다.
+-- 예시: userId=11, status IN ('COMPLETED','REFUND_PENDING','REFUNDED')
+EXPLAIN ANALYZE
+SELECT
+    r.reservation_id AS reservationId,
+    r.reservation_code AS reservationCode,
+    res.restaurant_id AS restaurantId,
+    res.name AS restaurantName,
+    CONCAT(res.road_address, ' ', res.detail_address) AS restaurantAddress,
+    slot.slot_date AS slotDate,
+    slot.slot_time AS slotTime,
+    r.party_size AS partySize,
+    r.status AS reservationStatus,
+    CASE
+        WHEN r.status = 'COMPLETED' THEN rvs.visit_number
+        ELSE NULL
+    END AS visitCount,
+    CASE
+        WHEN r.status = 'COMPLETED' THEN rvs.days_since_last_visit
+        ELSE NULL
+    END AS daysSinceLastVisit,
+    rc.confirmed_amount AS receiptAmount,
+    pay.paid_amount AS paidAmount,
+    r.total_amount AS totalAmount,
+    rv.review_id AS reviewId,
+    rv.rating AS reviewRating,
+    rv.content AS reviewContent,
+    DATE(rv.created_at) AS reviewCreatedAt,
+    GROUP_CONCAT(DISTINCT rt.name ORDER BY rt.tag_id SEPARATOR '||') AS reviewTags
+FROM reservations r
+JOIN restaurant_reservation_slots slot ON slot.slot_id = r.slot_id
+JOIN restaurants res ON res.restaurant_id = slot.restaurant_id
+LEFT JOIN receipts rc ON rc.reservation_id = r.reservation_id
+LEFT JOIN reservation_visit_stats rvs ON rvs.reservation_id = r.reservation_id
+LEFT JOIN reviews rv ON rv.reservation_id = r.reservation_id
+LEFT JOIN review_tag_maps rtm ON rtm.review_id = rv.review_id
+LEFT JOIN review_tags rt ON rt.tag_id = rtm.tag_id
+LEFT JOIN (
+    SELECT reservation_id, SUM(amount) AS paid_amount
+    FROM payments
+    WHERE status = 'PAID'
+    GROUP BY reservation_id
+) pay ON pay.reservation_id = r.reservation_id
+WHERE r.user_id = 11
+  AND r.status IN ('COMPLETED', 'REFUND_PENDING', 'REFUNDED')
+GROUP BY
+    r.reservation_id,
+    r.reservation_code,
+    res.restaurant_id,
+    res.name,
+    res.road_address,
+    res.detail_address,
+    slot.slot_date,
+    slot.slot_time,
+    r.party_size,
+    r.status,
+    rvs.visit_number,
+    rvs.days_since_last_visit,
+    rc.confirmed_amount,
+    pay.paid_amount,
+    r.total_amount,
+    rv.review_id,
+    rv.rating,
+    rv.content,
+    rv.created_at
+ORDER BY slot.slot_date DESC, slot.slot_time DESC;

--- a/src/main/resources/sql/seed_reservation_history_perf.sql
+++ b/src/main/resources/sql/seed_reservation_history_perf.sql
@@ -1,0 +1,135 @@
+-- Seed data for reservation history performance comparison
+-- 목적: 예약/리뷰/태그 데이터를 늘려 EXPLAIN ANALYZE 비교에 활용한다.
+
+USE lunchgo;
+
+SET @target_user = 11;
+SET @target_restaurant = 1;
+SET @start_date = '2024-01-01';
+SET @days = 120;
+SET @party_size = 2;
+SET @status = 'COMPLETED';
+
+-- 1) 예약 슬롯 생성 (일자별 1개)
+INSERT IGNORE INTO restaurant_reservation_slots (restaurant_id, slot_date, slot_time, max_capacity)
+SELECT
+    @target_restaurant,
+    DATE_ADD(@start_date, INTERVAL seq.n DAY),
+    '12:00:00',
+    30
+FROM (
+    SELECT (a.n + b.n * 10 + c.n * 100) AS n
+    FROM (
+        SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+        UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9
+    ) a
+    CROSS JOIN (
+        SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+        UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9
+    ) b
+    CROSS JOIN (
+        SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+        UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9
+    ) c
+    WHERE (a.n + b.n * 10 + c.n * 100) < @days
+) seq;
+
+-- 2) 예약 생성 (슬롯 기준, reservation_id는 AUTO_INCREMENT)
+INSERT INTO reservations
+    (reservation_code, slot_id, user_id, party_size, reservation_type, status, request_message,
+     deposit_amount, prepay_amount, total_amount, currency, hold_expires_at, payment_deadline_at, created_at, updated_at)
+SELECT
+    CONCAT('RPERF', DATE_FORMAT(slot.slot_date, '%Y%m%d'), '-', LPAD(slot.slot_id, 5, '0')),
+    slot.slot_id,
+    @target_user,
+    @party_size,
+    'RESERVATION_DEPOSIT',
+    @status,
+    NULL,
+    10000,
+    NULL,
+    50000,
+    'KRW',
+    NULL,
+    NULL,
+    CONCAT(slot.slot_date, ' 11:00:00'),
+    CONCAT(slot.slot_date, ' 11:00:00')
+FROM restaurant_reservation_slots slot
+LEFT JOIN reservations r
+    ON r.slot_id = slot.slot_id
+   AND r.user_id = @target_user
+WHERE slot.restaurant_id = @target_restaurant
+  AND slot.slot_date BETWEEN @start_date AND DATE_ADD(@start_date, INTERVAL @days - 1 DAY)
+  AND r.reservation_id IS NULL;
+
+-- 3) 리뷰 생성 (예약 대비 1:1, 기존 리뷰는 제외)
+INSERT INTO reviews
+    (restaurant_id, user_id, reservation_id, receipt_id, rating, content, created_at, updated_at, status)
+SELECT
+    @target_restaurant,
+    @target_user,
+    r.reservation_id,
+    NULL,
+    4,
+    CONCAT('성능 테스트 리뷰 ', r.reservation_id),
+    r.created_at,
+    r.updated_at,
+    'PUBLIC'
+FROM reservations r
+LEFT JOIN reviews rv ON rv.reservation_id = r.reservation_id
+WHERE r.user_id = @target_user
+  AND r.status = 'COMPLETED'
+  AND rv.review_id IS NULL;
+
+-- 4) 리뷰 태그 매핑 (리뷰당 2개 태그 부여)
+INSERT INTO review_tag_maps (review_id, tag_id)
+SELECT rv.review_id, 1 + (rv.review_id % 5)
+FROM reviews rv
+LEFT JOIN review_tag_maps m ON m.review_id = rv.review_id
+WHERE rv.user_id = @target_user
+  AND m.review_id IS NULL;
+
+INSERT INTO review_tag_maps (review_id, tag_id)
+SELECT rv.review_id, 6 + (rv.review_id % 5)
+FROM reviews rv
+LEFT JOIN review_tag_maps m ON m.review_id = rv.review_id
+WHERE rv.user_id = @target_user
+  AND m.review_id IS NULL;
+
+-- 5) 영수증 생성 (예약당 1건, 기존 영수증은 제외)
+INSERT INTO receipts
+    (reservation_id, confirmed_amount, image_url, created_at)
+SELECT
+    r.reservation_id,
+    r.total_amount,
+    NULL,
+    r.created_at
+FROM reservations r
+LEFT JOIN receipts rc ON rc.reservation_id = r.reservation_id
+WHERE r.user_id = @target_user
+  AND r.status = 'COMPLETED'
+  AND rc.receipt_id IS NULL;
+
+-- 6) 결제 데이터 (예약당 1건, 기존 결제는 제외)
+INSERT INTO payments
+(reservation_id, payment_type, status, method, card_type, amount, currency, pg_provider, requested_at, created_at, updated_at)
+SELECT
+    r.reservation_id,
+    'DEPOSIT',
+    'PAID',
+    'CARD',
+    'CORPORATE',
+    r.deposit_amount,
+    'KRW',
+    'PORTONE',
+    r.created_at,
+    r.created_at,
+    r.updated_at
+FROM reservations r
+         LEFT JOIN payments p
+                   ON p.reservation_id = r.reservation_id
+                       AND p.payment_type = 'DEPOSIT'
+WHERE r.user_id = @target_user
+  AND r.status = 'COMPLETED'
+  AND r.deposit_amount IS NOT NULL
+  AND p.payment_id IS NULL;


### PR DESCRIPTION
  ## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

  - 예약 완료 스냅샷 테이블(reservation_visit_stats) 도입 및 백필 포함 마이그레이션 추가
  - 지난 예약 조회 로직을 스냅샷 기반(reservation_visit_stats)으로 전환해 윈도우 함수 제거
  - 예약 완료 처리 API 추가(PATCH /api/reservations/{id}/complete) 및 권한 설정(ROLE_OWNER) (@dhkdxh)
  - 지난 예약 탭에 검색/필터/페이지네이션 UI 추가 (리뷰 페이지 Pagination 컴포넌트 재사용)

지난 예약 탭 UI 수정
<img width="512" height="951" alt="스크린샷 2026-01-02 오후 1 11 34" src="https://github.com/user-attachments/assets/9966557f-add7-41ba-bddc-f628a9e468bc" />

예약 완료 스냅샷 테이블 추가
<img width="834" height="398" alt="image" src="https://github.com/user-attachments/assets/9ff1b1d2-ae8e-475c-87dd-cfe2294148e4" />

쿼리 실행 시간 단축 결과 (스냅샷 테이블 추가에 따라 정확성 및 성능 향상)
<img width="751" height="341" alt="image" src="https://github.com/user-attachments/assets/49683346-8314-4e95-88be-9b016b14d7a9" />


  ## 📁 변경된 파일

  - frontend/src/views/my-reservations/MyReservationsPage.vue
  - src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
  - src/main/java/com/example/LunchGo/reservation/controller/ReservationController.java
  - src/main/java/com/example/LunchGo/reservation/mapper/ReservationVisitStatsMapper.java
  - src/main/resources/mapper/ReservationHistoryMapper.xml
  - src/main/resources/mapper/ReservationVisitStatsMapper.xml
  - src/main/resources/sql/migration_add_reservation_visit_stats.sql
  - src/main/resources/sql/reservation_history_query_explain_analyze.sql
  - src/main/resources/sql/seed_reservation_history_perf.sql
  - docs/reservation-history-query-analysis.md

  ## 공유사항 to 리뷰어 <!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요.-->
- @dhkdxh  개발 예정이던 완료 처리 API를 지난 예약에서 리뷰 생성간 필요하여 이번 작업에서 포함했습니다. 충돌/중복 여부 확인 부탁드립니다.