### PR TITLE
feat(security): 사용자, 사업자, 임직원 로그인한 객체 정보 필드 수정

### DIFF
--- a/frontend/src/components/ui/BusinessHeader.vue
+++ b/frontend/src/components/ui/BusinessHeader.vue
@@ -22,7 +22,7 @@ const getStoredMember = () => {
 const member = computed(() => accountStore.member || getStoredMember());
 const userName = computed(() => {
   if(member.value?.role === 'ROLE_OWNER' || member.value?.role === 'ROLE_STAFF'){
-    return member.value.email;
+    return member.value.name;
   }
   return '사용자';
 });

--- a/src/main/java/com/example/LunchGo/account/dto/CustomUserDetails.java
+++ b/src/main/java/com/example/LunchGo/account/dto/CustomUserDetails.java
@@ -20,13 +20,17 @@ public class CustomUserDetails implements UserDetails {
     private final String password;
     private final String role;
     private final String status; //user, owner의 상태
+    private final String name; //user, owner, staff 필요
+    private final String image; //user 필요
 
-    public CustomUserDetails(Long id, String email, String password, String role, String status) {
+    public CustomUserDetails(Long id, String email, String password, String role, String status, String name, String image) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.role = role;
         this.status = status;
+        this.name = name;
+        this.image = image;
     }
 
     // JWT 인증 필터용 생성자
@@ -37,29 +41,31 @@ public class CustomUserDetails implements UserDetails {
         this.email = "";      // 토큰엔 이메일이 없으니 빈 값 (필요하면 토큰에 email도 넣어야 함)
         this.password = "";   // 인증된 토큰이므로 비밀번호 불필요
         this.status = "ACTIVE"; // 토큰이 유효하다는 건 활동 가능한 상태로 간주 (isEnabled 통과를 위해 ACTIVE 필수)
+        this.name = "";
+        this.image = "";
     }
 
     public static CustomUserDetails from(User user) {
         return new CustomUserDetails(
-                user.getUserId(), user.getEmail(), user.getPassword(),"ROLE_USER", user.getStatus().name()
+                user.getUserId(), user.getEmail(), user.getPassword(),"ROLE_USER", user.getStatus().name(), user.getName(), user.getImage()
         );
     }
 
     public static CustomUserDetails from(Owner owner){
         return new CustomUserDetails(
-                owner.getOwnerId(), owner.getLoginId(), owner.getPassword(),"ROLE_OWNER", owner.getStatus().name()
+                owner.getOwnerId(), owner.getLoginId(), owner.getPassword(),"ROLE_OWNER", owner.getStatus().name(), owner.getName(), null
         );
     }
 
     public static CustomUserDetails from(Staff staff) {
         return new CustomUserDetails(
-                staff.getStaffId(), staff.getEmail(), staff.getPassword(),"ROLE_STAFF", "ACTIVE"
+                staff.getStaffId(), staff.getEmail(), staff.getPassword(),"ROLE_STAFF", "ACTIVE", staff.getName(), null
         );
     }
 
     public static CustomUserDetails from(Manager manager) {
         return new CustomUserDetails(
-                manager.getManagerId(), manager.getLoginId(), manager.getPassword(),"ROLE_ADMIN", "ACTIVE"
+                manager.getManagerId(), manager.getLoginId(), manager.getPassword(),"ROLE_ADMIN", "ACTIVE", null, null
         );
     }
 

--- a/src/main/java/com/example/LunchGo/account/dto/MemberLogin.java
+++ b/src/main/java/com/example/LunchGo/account/dto/MemberLogin.java
@@ -12,5 +12,7 @@ public class MemberLogin {
     private String email;
     private String password;
     private String role;
+    private String name;
+    private String image;
     private String accessToken;
 }

--- a/src/main/java/com/example/LunchGo/account/helper/AccountHelperImpl.java
+++ b/src/main/java/com/example/LunchGo/account/helper/AccountHelperImpl.java
@@ -98,6 +98,8 @@ public class AccountHelperImpl implements AccountHelper {
                 .id(userDetails.getId())
                 .email(userDetails.getEmail())
                 .role(userDetails.getRole())
+                .name(userDetails.getName())
+                .image(userDetails.getImage())
                 .accessToken(tokenDTO.getAccessToken())
                 .build();
     }


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 사용자, 사업자, 임직원의 로그인한 객체 정보(MemberLogin) 필드 수정
- 사용자는 프로필 사진이 우측 상단에 보이게 됨
- 사업자 및 임직원은 자신의 이름+"님 안녕하세요!"를 보게 됨(기존에는 loginId or email이라 가독성이 떨어졌음)

## 📁 변경된 파일

- BusinessHeader.vue
- AppHeader.vue
- CustomUserDetails.java
- MemberLogin.vue
- AccountHelperImpl.java

## 🔗 관련 Issue(선택)

- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/285

## ✔️ 체크리스트(선택)
- 이렇게 등록한 사진이 있으면 등록한 사진을 불러와서 보일 수 있게 수정
<img width="657" height="893" alt="image" src="https://github.com/user-attachments/assets/a1bc428a-b8a9-483b-8217-12431ee9ba6f" />
