### PR TITLE
feat(algorithm): 예산 한도 매핑 알고리즘 구현

### DIFF
--- a/frontend/src/composables/useBudgetRecommendation.js
+++ b/frontend/src/composables/useBudgetRecommendation.js
@@ -1,0 +1,42 @@
+import { ref } from "vue";
+import { restaurants as restaurantData } from "@/data/restaurants";
+
+export const extractPriceValue = (priceText = "") => {
+  const match = priceText.match(/([\d.,]+)/);
+  const target = match?.[1] ?? priceText;
+  const digits = String(target).replace(/[^0-9]/g, "");
+  if (!digits) return null;
+  return Number(digits);
+};
+
+const filterByBudget = (perPersonBudget) => {
+  const budget = Number(perPersonBudget);
+  if (!Number.isFinite(budget) || budget <= 0) {
+    return [];
+  }
+  return restaurantData.filter((restaurant) => {
+    const priceValue = extractPriceValue(restaurant?.price ?? "");
+    if (priceValue == null) return false;
+    if(budget >= 500000) return priceValue >= Number(500000*0.9); //상한
+    if(budget <= 10000) return priceValue <= Number(10000*1.1); //하한
+    return (priceValue <= Number(budget*1.1)) && (priceValue >= Number(budget*0.9));
+  });
+};
+
+export function useBudgetRecommendation() {
+  const budgetRecommendations = ref([]);
+
+  const fetchBudgetRecommendations = (perPersonBudget) => {
+    budgetRecommendations.value = filterByBudget(perPersonBudget);
+  };
+
+  const clearBudgetRecommendations = () => {
+    budgetRecommendations.value = [];
+  };
+
+  return {
+    budgetRecommendations,
+    fetchBudgetRecommendations,
+    clearBudgetRecommendations,
+  };
+}


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 사용자(+비회원)가 한 정해진 예산에 대한 한도 및 인원 수를 입력하면 1인당 금액을 계산하여 해당 금액의 상하한 10%의 금액에 해당하는 식당의 주메뉴평균가를 가진 식당을 필터링하는 알고리즘
- 페이지 업로드시 식당 정보는 이미 저장되어 있으므로 해당 식당 정보를 기반으로 알고리즘 식만 세워주면 됨
- 아래의 사진과 같이 상한과 하한을 정하여 유동적으로 식당을 보여주게 필터링
<img width="1071" height="211" alt="image" src="https://github.com/user-attachments/assets/abf9935e-1993-4391-b6b3-a6302661dfc0" />

## 📁 변경된 파일

- HomeView.vue
- useBudgetRecommendation.js

## 🔗 관련 Issue(선택)

- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/288

## ✔️ 체크리스트(선택)

- 필터링까지 테스트 통과 완료
<img width="596" height="855" alt="image" src="https://github.com/user-attachments/assets/c66f1840-5c38-46e0-a356-b08b91aef6bb" />

해당 사진처럼 35,000원이 나오면, 31,500-38.500이 주메뉴평균가인 식당 리스트를 필터링
<img width="620" height="895" alt="image" src="https://github.com/user-attachments/assets/2b914201-8f24-4334-8f43-b42e3dd5cc71" />
