### PR TITLE
feat: 백엔드 자동 배포를 위한 prod.properties추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 application-secret.properties
-src/main/resources/application-prod.properties
 AWSCLIV2.pkg
 
 ## mac OS 때문에 생기는 파일

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,60 @@
+spring.application.name=LunchGo
+
+# Database
+spring.datasource.url=jdbc:mysql://10.0.2.6:3306/lunchgo?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&characterEncoding=UTF-8
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# Redis
+spring.data.redis.host=10.0.2.6
+spring.data.redis.port=6379
+spring.data.redis.password=${REDIS_PASSWORD}
+
+# Object Storage
+ncp.object-storage.endpoint=https://kr.object.ncloudstorage.com
+ncp.object-storage.region=kr-standard
+ncp.object-storage.bucket=lunchgo-storage
+ncp.object-storage.public-read=true
+ncp.object-storage.max-size-bytes=10485760
+ncp.object-storage.allowed-content-types=image/jpeg,image/png,image/webp
+ncp.object-storage.access-key=${NCP_OBJECT_STORAGE_ACCESS_KEY}
+ncp.object-storage.secret-key=${NCP_OBJECT_STORAGE_SECRET_KEY}
+
+# Clova OCR
+naver.clova.ocr.secret=${NAVER_CLOVA_OCR_SECRET}
+naver.clova.ocr.invoke-url=${NAVER_CLOVA_OCR_INVOKE_URL}
+naver.clova.ocr.general.secret=${NAVER_CLOVA_OCR_GENERAL_SECRET}
+naver.clova.ocr.general.invoke-url=${NAVER_CLOVA_OCR_GENERAL_INVOKE_URL}
+
+# CoolSMS
+coolsms.apiKey=${COOLSMS_API_KEY}
+coolsms.secretkey=${COOLSMS_SECRET_KEY}
+coolsms.from=${COOLSMS_FROM}
+
+# Mail (SMTP)
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${SMTP_USERNAME}
+spring.mail.password=${SMTP_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true
+spring.mail.properties.mail.smtp.connectiontimeout=5000
+spring.mail.properties.mail.smtp.timeout=5000
+spring.mail.properties.mail.smtp.writetimeout=5000
+mail.auth-code-expiration-millis=180000
+
+# Portone
+portone.store-id=${PORTONE_STORE_ID}
+portone.channel-key=${PORTONE_CHANNEL_KEY}
+portone.api-base=https://api.portone.io
+portone.api-secret=${PORTONE_API_SECRET}
+portone.webhook-secret=${PORTONE_WEBHOOK_SECRET}
+
+# Security
+custom.jwt.secret=${JWT_SECRET}
+
+# Multipart limits
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- github actions를 통한 백엔드(spring boot) 자동 배포 성공
<img width="1411" height="811" alt="스크린샷 2026-01-03 오후 5 31 38" src="https://github.com/user-attachments/assets/b8046b1b-2fca-4f6e-97bd-6628a26991a2" />

- 자동 배포는 github actions로 되었으나, application-prod.properties가 기존에 gitignore처리되어, 배포된 코드에는 url이 존재하지 않아 백엔드서버가 제대로 켜지지 않아서 application-prod.properties를 무시하지 않고 추가함.


## 📁 변경된 파일

- application-prod.properties

## 공유사항 to 리뷰어 <!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요.-->

## 🔗 관련 Issue(선택)

-

## ✔️ 체크리스트(선택)

- ex) 테스트 통과 확인
