### PR TITLE
feat: 프론트엔드 코드 자동 배포 테스트 완료 및 github actions 코드 추가

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,0 +1,41 @@
+name: Frontend Deploy to Object Storage
+
+on:
+  push:
+    branches: ["dev"]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-deploy.yml"
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      VITE_API_BASE_URL: http://${{ secrets.SERVER_IP }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.NCP_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.NCP_SECRET_KEY }}
+      AWS_S3_FORCE_PATH_STYLE: "true"
+      BUCKET: ${{ secrets.NCP_BUCKET_NAME }}
+      ENDPOINT_URL: http://kr.object.ncloudstorage.com
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Build frontend
+        run: npm run build
+        working-directory: frontend
+
+      - name: Install awscli
+        run: python -m pip install --upgrade pip awscli
+
+      - name: Upload dist to Object Storage
+        run: |
+          aws --endpoint-url="${ENDPOINT_URL}" s3 sync \
+            frontend/dist "s3://${BUCKET}" --delete

--- a/scripts/upload_frontend_object_storage.sh
+++ b/scripts/upload_frontend_object_storage.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 DIST_DIR="${DIST_DIR:-frontend/dist}"
 BUCKET="${BUCKET:-lunchgo-test-bucket}"
 REGION="${REGION:-kr-standard}"
-ENDPOINT_URL="${ENDPOINT_URL:-https://kr.object.ncloudstorage.com}"
+ENDPOINT_URL="${ENDPOINT_URL:-http://kr.object.ncloudstorage.com}"
 ACL="${ACL:-}"
 DRY_RUN="${DRY_RUN:-0}"
 


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->
  - 프론트 GitHub Actions 자동 배포 워크플로 추가
  - Object Storage 업로드 스크립트 기본 엔드포인트를 http로 변경
  - 배포 문서에 NCP 키/버킷명 기준 및 업로드 트러블슈팅 보강

  ## 📁 변경된 파일
  - .github/workflows/frontend-deploy.yml
  - docs/naver-cloud-vpc-deployment.md
  - scripts/upload_frontend_object_storage.sh

  ## 공유사항 to 리뷰어 <!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요.-->
  - Object Storage CLI 업로드는 `https`에서 `AccessDenied`가 발생해 `http://kr.object.ncloudstorage.com`으로 사용합니다.
  - 프론트 배포 Secrets는 기존 `NCP_ACCESS_KEY`, `NCP_SECRET_KEY`, `NCP_BUCKET_NAME`, `SERVER_IP`를 재사용합니다.

  ## 🔗 관련 Issue(선택)
  -

  ## ✔️ 체크리스트(선택)
  - 로컬에서 프론트 빌드 및 Object Storage 업로드 확인 
<img width="1289" height="301" alt="image" src="https://github.com/user-attachments/assets/0d7dc97e-4cc8-4bdf-8cc0-f004df0489f8" />
<img width="1306" height="163" alt="image" src="https://github.com/user-attachments/assets/6e4f1508-51e1-4cdf-a698-ddeac388ec2a" />
