### PR TITLE
chore: 스카우터 배포 환경 업데이트 및 문서 업데이트

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -58,5 +58,6 @@ jobs:
               docker pull pgw10243/lunchgo-backend:dev
               docker run --env-file /opt/lunchgo/.env \
                 -e SCOUTER_OBJ_NAME=lunchgo-prod-$(hostname) \
+                -v /opt/scouter/scouter/agent.java/conf/scouter.conf:/app/scouter/conf/scouter.conf:ro \
                 -p 8080:8080 --name lunchgo-backend -d pgw10243/lunchgo-backend:dev
             "

--- a/src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
@@ -122,7 +122,8 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(List.of(
                 "http://localhost:5173",
                 "http://localhost:8080",
-                "http://lunchgo-test-bucket.s3-website.kr.object.ncloudstorage.com"
+                "http://lunchgo-test-bucket.s3-website.kr.object.ncloudstorage.com",
+                "https://lunchgo-test-bucket.s3-website.kr.object.ncloudstorage.com"
         ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-type", "X-Requested-With"));


### PR DESCRIPTION
## 📌 작업 내용

  - Scouter 배포 시 conf 마운트 추가로 자동배포 안정화
  - Nginx CORS 프리플라이트 처리와 Scouter 트러블슈팅 문서 보강
  - 인증 관련 설정 변경 반영

## 📁 변경된 파일

  - .github/workflows/backend-deploy.yml
  - docs/apm-scouter-setup.md
  - docs/naver-cloud-vpc-deployment.md
  - src/main/java/com/example/LunchGo/common/config/SecurityConfig.java

## 공유사항 to 리뷰어

  - 자동배포 시 Scouter agent는 이미지 내 포함, scouter.conf만 마운트하도록 정리
  - Collector UDP(6100) 오픈 필요 및 운영 트러블슈팅 문서화
 
## ✔️ 체크리스트(선택)

- scouter client 에 object 연동 확인
<img width="1342" height="1028" alt="image" src="https://github.com/user-attachments/assets/4d251793-ffef-47fd-af61-6dc3e54dbdcb" />

