### PR TITLE
feat(restaurant): 일반 사용자/비회원용 식당 상세조회 api 프론트 연동

### DIFF
--- a/frontend/src/data/restaurants.js
+++ b/frontend/src/data/restaurants.js
@@ -1,6 +1,6 @@
 export const restaurants = [
   {
-    id: '1',
+    id: '4',
     name: '감미옥 본점',
     category: '기타',
     rating: 0,
@@ -39,7 +39,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '2',
+    id: '5',
     name: '강남면옥 분당점',
     category: '기타',
     rating: 0,
@@ -78,7 +78,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '3',
+    id: '6',
     name: '경복궁 판교점',
     category: '기타',
     rating: 0,
@@ -117,7 +117,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '4',
+    id: '7',
     name: '고미고미',
     category: '기타',
     rating: 0,
@@ -156,7 +156,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '5',
+    id: '8',
     name: '광화문국밥 판교점',
     category: '기타',
     rating: 0,
@@ -195,7 +195,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '6',
+    id: '9',
     name: '교대이층집 서현점',
     category: '기타',
     rating: 0,
@@ -234,7 +234,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '7',
+    id: '10',
     name: '그집',
     category: '기타',
     rating: 0,
@@ -273,7 +273,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '8',
+    id: '11',
     name: '긴자 백현점',
     category: '기타',
     rating: 0,
@@ -312,7 +312,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '9',
+    id: '12',
     name: '긴자 판교점',
     category: '기타',
     rating: 0,
@@ -351,7 +351,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '10',
+    id: '13',
     name: '김초생초',
     category: '기타',
     rating: 0,
@@ -390,7 +390,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '11',
+    id: '14',
     name: '나라돈까스',
     category: '기타',
     rating: 0,
@@ -429,7 +429,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '12',
+    id: '15',
     name: '나지미돈부리',
     category: '기타',
     rating: 0,
@@ -468,7 +468,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '13',
+    id: '16',
     name: '내뜨락',
     category: '기타',
     rating: 0,
@@ -507,7 +507,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '14',
+    id: '17',
     name: '너와집백합샤브샤브 백현점',
     category: '기타',
     rating: 0,
@@ -546,7 +546,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '15',
+    id: '18',
     name: '니고라멘',
     category: '기타',
     rating: 0,
@@ -585,7 +585,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '16',
+    id: '19',
     name: '다이호시',
     category: '기타',
     rating: 0,
@@ -624,7 +624,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '17',
+    id: '20',
     name: '닥터로빈 시그니처 판교점',
     category: '기타',
     rating: 0,
@@ -663,7 +663,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '18',
+    id: '21',
     name: '도원참치 판교본점',
     category: '기타',
     rating: 0,
@@ -702,7 +702,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '19',
+    id: '22',
     name: '도쿄스테이크 서현역점',
     category: '기타',
     rating: 0,
@@ -741,7 +741,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '20',
+    id: '23',
     name: '돈가스맘',
     category: '기타',
     rating: 0,
@@ -780,7 +780,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '21',
+    id: '24',
     name: '돈블랑 판교점',
     category: '기타',
     rating: 0,
@@ -819,7 +819,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '22',
+    id: '25',
     name: '동청담 삼평직영점',
     category: '기타',
     rating: 0,
@@ -858,7 +858,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '23',
+    id: '26',
     name: '돼지맨숀',
     category: '기타',
     rating: 0,
@@ -897,7 +897,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '24',
+    id: '27',
     name: '두부공방 분당정자본점',
     category: '기타',
     rating: 0,
@@ -936,7 +936,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '25',
+    id: '28',
     name: '람바다',
     category: '기타',
     rating: 0,
@@ -975,7 +975,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '26',
+    id: '29',
     name: '레스토랑마고',
     category: '기타',
     rating: 0,
@@ -1014,7 +1014,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '27',
+    id: '30',
     name: '리얼스페인 판교점',
     category: '기타',
     rating: 0,
@@ -1053,7 +1053,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '28',
+    id: '31',
     name: '마루심 판교점',
     category: '기타',
     rating: 0,
@@ -1092,7 +1092,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '29',
+    id: '32',
     name: '마초야 수내직영점',
     category: '기타',
     rating: 0,
@@ -1131,7 +1131,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '30',
+    id: '33',
     name: '마키노차야 판교점',
     category: '기타',
     rating: 0,
@@ -1170,7 +1170,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '31',
+    id: '34',
     name: '몽중헌 판교점',
     category: '기타',
     rating: 0,
@@ -1209,7 +1209,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '32',
+    id: '35',
     name: '미방 정자점',
     category: '기타',
     rating: 0,
@@ -1248,7 +1248,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '33',
+    id: '36',
     name: '미스터스시 정자점',
     category: '기타',
     rating: 0,
@@ -1287,7 +1287,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '34',
+    id: '37',
     name: '미카도',
     category: '기타',
     rating: 0,
@@ -1326,7 +1326,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '35',
+    id: '38',
     name: '방유당 그레이츠판교점',
     category: '기타',
     rating: 0,
@@ -1365,7 +1365,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '36',
+    id: '39',
     name: '백마강참숯민물장어 판교점',
     category: '기타',
     rating: 0,
@@ -1404,7 +1404,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '37',
+    id: '40',
     name: '봉피양 판교점',
     category: '기타',
     rating: 0,
@@ -1443,7 +1443,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '38',
+    id: '41',
     name: '부성초밥',
     category: '기타',
     rating: 0,
@@ -1482,7 +1482,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '39',
+    id: '42',
     name: '붓처스컷 아브뉴프랑 판교점',
     category: '기타',
     rating: 0,
@@ -1521,7 +1521,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '40',
+    id: '43',
     name: '블루핀튜나',
     category: '기타',
     rating: 0,
@@ -1560,7 +1560,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '41',
+    id: '44',
     name: '빈티지1988',
     category: '기타',
     rating: 0,
@@ -1599,7 +1599,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '42',
+    id: '45',
     name: '뿅의전설 본점',
     category: '기타',
     rating: 0,
@@ -1638,7 +1638,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '43',
+    id: '46',
     name: '사위식당 판교점',
     category: '기타',
     rating: 0,
@@ -1677,7 +1677,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '44',
+    id: '47',
     name: '사카나',
     category: '기타',
     rating: 0,
@@ -1716,7 +1716,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '45',
+    id: '48',
     name: '삼김화로구이',
     category: '기타',
     rating: 0,
@@ -1755,7 +1755,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '46',
+    id: '49',
     name: '삼돌이',
     category: '기타',
     rating: 0,
@@ -1794,7 +1794,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '47',
+    id: '50',
     name: '삿뽀로 판교점',
     category: '기타',
     rating: 0,
@@ -1833,7 +1833,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '48',
+    id: '51',
     name: '상무초밥 분당서현점',
     category: '기타',
     rating: 0,
@@ -1872,7 +1872,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '49',
+    id: '52',
     name: '샤브올데이 분당서현점',
     category: '기타',
     rating: 0,
@@ -1911,7 +1911,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '50',
+    id: '53',
     name: '서울24시감자탕 서현3호점',
     category: '기타',
     rating: 0,
@@ -1950,7 +1950,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '51',
+    id: '54',
     name: '서울멸치쌈밥',
     category: '기타',
     rating: 0,
@@ -1989,7 +1989,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '52',
+    id: '55',
     name: '서현궁 백현점',
     category: '기타',
     rating: 0,
@@ -2028,7 +2028,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '53',
+    id: '56',
     name: '서현실비',
     category: '기타',
     rating: 0,
@@ -2067,7 +2067,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '54',
+    id: '57',
     name: '서호돈가스 판교점',
     category: '기타',
     rating: 0,
@@ -2106,7 +2106,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '55',
+    id: '58',
     name: '선영국밥',
     category: '기타',
     rating: 0,
@@ -2145,7 +2145,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '56',
+    id: '59',
     name: '선한레시피 판교점',
     category: '기타',
     rating: 0,
@@ -2184,7 +2184,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '57',
+    id: '60',
     name: '송도갈비 판교브릿지타워점',
     category: '기타',
     rating: 0,
@@ -2223,7 +2223,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '58',
+    id: '61',
     name: '수타우동겐 본점',
     category: '기타',
     rating: 0,
@@ -2262,7 +2262,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '59',
+    id: '62',
     name: '숙성도 판교점',
     category: '기타',
     rating: 0,
@@ -2301,7 +2301,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '60',
+    id: '63',
     name: '쉐누하누',
     category: '기타',
     rating: 0,
@@ -2340,7 +2340,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '61',
+    id: '64',
     name: '스시가좋아서',
     category: '기타',
     rating: 0,
@@ -2379,7 +2379,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '62',
+    id: '65',
     name: '스시강',
     category: '기타',
     rating: 0,
@@ -2418,7 +2418,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '63',
+    id: '66',
     name: '스시료코',
     category: '기타',
     rating: 0,
@@ -2457,7 +2457,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '64',
+    id: '67',
     name: '스시소라 정자점',
     category: '기타',
     rating: 0,
@@ -2496,7 +2496,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '65',
+    id: '68',
     name: '스시앤스시 본점',
     category: '기타',
     rating: 0,
@@ -2535,7 +2535,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '66',
+    id: '69',
     name: '스시언',
     category: '기타',
     rating: 0,
@@ -2574,7 +2574,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '67',
+    id: '70',
     name: '스시혼 판교본점',
     category: '기타',
     rating: 0,
@@ -2613,7 +2613,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '68',
+    id: '71',
     name: '신도세기 판교역점',
     category: '기타',
     rating: 0,
@@ -2652,7 +2652,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '69',
+    id: '72',
     name: '신승반점 현대백화점 판교점',
     category: '기타',
     rating: 0,
@@ -2691,7 +2691,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '70',
+    id: '73',
     name: '양우정 판교점',
     category: '기타',
     rating: 0,
@@ -2730,7 +2730,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '71',
+    id: '74',
     name: '양재정육식당',
     category: '기타',
     rating: 0,
@@ -2769,7 +2769,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '72',
+    id: '75',
     name: '여기풍천민물장어',
     category: '기타',
     rating: 0,
@@ -2808,7 +2808,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '73',
+    id: '76',
     name: '오마카세 스시이찌 판교점',
     category: '기타',
     rating: 0,
@@ -2847,7 +2847,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '74',
+    id: '77',
     name: '오복수산 판교점',
     category: '기타',
     rating: 0,
@@ -2886,7 +2886,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '75',
+    id: '78',
     name: '우설화 판교점',
     category: '기타',
     rating: 0,
@@ -2925,7 +2925,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '76',
+    id: '79',
     name: '울프스덴',
     category: '기타',
     rating: 0,
@@ -2964,7 +2964,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '77',
+    id: '80',
     name: '워모잡',
     category: '기타',
     rating: 0,
@@ -3003,7 +3003,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '78',
+    id: '81',
     name: '원복집',
     category: '기타',
     rating: 0,
@@ -3042,7 +3042,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '79',
+    id: '82',
     name: '유타로 서현직영점',
     category: '기타',
     rating: 0,
@@ -3081,7 +3081,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '80',
+    id: '83',
     name: '육화몽 서현점',
     category: '기타',
     rating: 0,
@@ -3120,7 +3120,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '81',
+    id: '84',
     name: '윤밀원',
     category: '기타',
     rating: 0,
@@ -3159,7 +3159,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '82',
+    id: '85',
     name: '이가네양갈비 판교직영점',
     category: '기타',
     rating: 0,
@@ -3198,7 +3198,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '83',
+    id: '86',
     name: '이춘복참치 판교',
     category: '기타',
     rating: 0,
@@ -3237,7 +3237,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '84',
+    id: '87',
     name: '이태리부대찌개 판교점',
     category: '기타',
     rating: 0,
@@ -3276,7 +3276,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '85',
+    id: '88',
     name: '인디안커리',
     category: '기타',
     rating: 0,
@@ -3315,7 +3315,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '86',
+    id: '89',
     name: '자산어보 판교직영점',
     category: '기타',
     rating: 0,
@@ -3354,7 +3354,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '87',
+    id: '90',
     name: '장수천한방민물장어 분당본점',
     category: '기타',
     rating: 0,
@@ -3393,7 +3393,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '88',
+    id: '91',
     name: '장원막국수',
     category: '기타',
     rating: 0,
@@ -3432,7 +3432,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '89',
+    id: '92',
     name: '전국5대짬뽕연화산',
     category: '기타',
     rating: 0,
@@ -3471,7 +3471,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '90',
+    id: '93',
     name: '정가네능이백숙',
     category: '기타',
     rating: 0,
@@ -3510,7 +3510,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '91',
+    id: '94',
     name: '정통춘천닭갈비',
     category: '기타',
     rating: 0,
@@ -3549,7 +3549,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '92',
+    id: '95',
     name: '조재벌식당',
     category: '기타',
     rating: 0,
@@ -3588,7 +3588,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '93',
+    id: '96',
     name: '주누돈까스냉면',
     category: '기타',
     rating: 0,
@@ -3627,7 +3627,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '94',
+    id: '97',
     name: '창고43 판교점',
     category: '기타',
     rating: 0,
@@ -3666,7 +3666,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '95',
+    id: '98',
     name: '천지연 판교점',
     category: '기타',
     rating: 0,
@@ -3705,7 +3705,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '96',
+    id: '99',
     name: '청담일식 서현점',
     category: '기타',
     rating: 0,
@@ -3744,7 +3744,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '97',
+    id: '100',
     name: '청담추어정 분당점',
     category: '기타',
     rating: 0,
@@ -3783,7 +3783,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '98',
+    id: '101',
     name: '청정갯마을 분당점',
     category: '기타',
     rating: 0,
@@ -3822,7 +3822,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '99',
+    id: '102',
     name: '최가돈까스',
     category: '기타',
     rating: 0,
@@ -3861,7 +3861,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '100',
+    id: '103',
     name: '카츠쇼쿠도우 판교본점',
     category: '기타',
     rating: 0,
@@ -3900,7 +3900,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '101',
+    id: '104',
     name: '코다리밥상 이매점',
     category: '기타',
     rating: 0,
@@ -3939,7 +3939,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '102',
+    id: '105',
     name: '코이라멘 지로2호점',
     category: '기타',
     rating: 0,
@@ -3978,7 +3978,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '103',
+    id: '106',
     name: '크래버대게나라 판교점',
     category: '기타',
     rating: 0,
@@ -4017,7 +4017,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '104',
+    id: '107',
     name: '탈리',
     category: '기타',
     rating: 0,
@@ -4056,7 +4056,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '105',
+    id: '108',
     name: '판교매일식당 판교본점',
     category: '기타',
     rating: 0,
@@ -4095,7 +4095,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '106',
+    id: '107',
     name: '팔복판교',
     category: '기타',
     rating: 0,
@@ -4134,7 +4134,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '107',
+    id: '110',
     name: '평가옥 판교점',
     category: '기타',
     rating: 0,
@@ -4173,7 +4173,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '108',
+    id: '111',
     name: '평양면옥 분당점',
     category: '기타',
     rating: 0,
@@ -4212,7 +4212,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '109',
+    id: '112',
     name: '푸에르코 판교점',
     category: '기타',
     rating: 0,
@@ -4251,7 +4251,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '110',
+    id: '113',
     name: '하누비노 서현점',
     category: '기타',
     rating: 0,
@@ -4290,7 +4290,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '111',
+    id: '114',
     name: '하루',
     category: '기타',
     rating: 0,
@@ -4329,7 +4329,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '112',
+    id: '115',
     name: '하루초밥 이매점',
     category: '기타',
     rating: 0,
@@ -4368,7 +4368,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '113',
+    id: '116',
     name: '하이보 판교점',
     category: '기타',
     rating: 0,
@@ -4407,7 +4407,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '114',
+    id: '117',
     name: '한소헌',
     category: '기타',
     rating: 0,
@@ -4446,7 +4446,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '115',
+    id: '118',
     name: '한점의희열 수내돈',
     category: '기타',
     rating: 0,
@@ -4485,7 +4485,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '116',
+    id: '119',
     name: '해우리 판교점',
     category: '기타',
     rating: 0,
@@ -4524,7 +4524,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '117',
+    id: '120',
     name: '행복치킨 정자점',
     category: '기타',
     rating: 0,
@@ -4563,7 +4563,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '118',
+    id: '121',
     name: '현복집 판교점',
     category: '기타',
     rating: 0,
@@ -4602,7 +4602,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '119',
+    id: '122',
     name: '호시',
     category: '기타',
     rating: 0,
@@ -4641,7 +4641,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '120',
+    id: '123',
     name: '화포식당 판교점',
     category: '기타',
     rating: 0,
@@ -4680,7 +4680,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '121',
+    id: '124',
     name: '황제갈비 판교점',
     category: '기타',
     rating: 0,
@@ -4719,7 +4719,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '122',
+    id: '125',
     name: '히카루후',
     category: '기타',
     rating: 0,


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 일반 사용자/비회원용 식당 상세 조회 api와 프론트 페이지 연동
- 프론트의 식당 id와 DB에서의 식당 id 간 불일치로 인한 데이터 정합성 문제 해결

## 📁 변경된 파일

- frontend/src/data/restaurants.js
- frontend/src/views/restaurant/id/RestaurantDetailPage.vue

## 공유사항 to 리뷰어 <!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요.-->

- HomeView.vue 파일에서는 restaurant.js의 데이터를 사용하되, restaurant.js 파일 내 식당ID는 기존 식당ID를 3 증가시킨 값으로 대체합니다.

## 🔗 관련 Issue(선택)

- [[FEATURE] 일반 사용자용 식당 상세조회 api 연동 #314](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/314)

## ✔️ 체크리스트(선택)

- api 연동 후 HomeView.vue에서 식당 선택 시 해당 식당의 상세정보 조회 페이지로 이동하는지 확인 (완료)
- 프론트에서 조회한 식당의 ID가 DB에서의 식당ID와 일치하는지 확인 (완료)
