### PR TITLE
feat: 메뉴 상세 페이지 API 연동 및 식당별 메뉴 표시 수정

### DIFF
--- a/frontend/src/views/restaurant/id/menus/RestaurantMenusPage.vue
+++ b/frontend/src/views/restaurant/id/menus/RestaurantMenusPage.vue
@@ -18,36 +18,24 @@ const fetchMenus = async () => {
   error.value = null;
   try {
     const response = await axios.get(`/api/restaurants/${restaurantId}/menus`);
-    menus.value = response.data;
+    menus.value = response.data || [];
   } catch (err) {
-    console.error("메뉴 정보를 불러오는 데 실패했습니다:", err);
-    error.value = "메뉴 정보를 불러오는 데 실패했습니다. 다시 시도해 주세요.";
+    console.error('메뉴 정보를 불러오는 데 실패했습니다:', err);
+    error.value = '메뉴 정보를 불러오는 데 실패했습니다. 다시 시도해 주세요.';
   } finally {
     isLoading.value = false;
   }
 };
 
-// flat으로 펴서 지금 UI 구조 유지
-const menuItems = computed(() =>
-    menuCategories.value.flatMap((cat) =>
-        cat.items.map((item) => ({
-          id: item.id,
-          name: item.name,
-          description: item.description,
-          category: cat.name,
-          price: parsePrice(item.price),
-          imageUrl: item.imageUrl || '',
-        })),
-    ),
-);
+onMounted(fetchMenus);
 
 const groupedMenus = computed(() => {
   if (!menus.value || menus.value.length === 0) {
     return [];
   }
-  
+
   const groups = menus.value.reduce((acc, menu) => {
-    const categoryName = menu.category.value;
+    const categoryName = menu.category?.value || menu.category?.code || '기타';
     if (!acc[categoryName]) {
       acc[categoryName] = [];
     }
@@ -69,10 +57,7 @@ const menuItemCount = computed(() => menus.value.length);
     <!-- Header -->
     <header class="sticky top-0 z-50 bg-white border-b border-[#e9ecef]">
       <div class="max-w-[500px] mx-auto px-4 h-14 flex items-center">
-        <RouterLink
-          :to="`/restaurant/${restaurantId}`"
-          class="mr-3"
-        >
+        <RouterLink :to="`/restaurant/${restaurantId}`" class="mr-3">
           <ArrowLeft class="w-6 h-6 text-[#1e3a5f]" />
         </RouterLink>
         <h1 class="font-semibold text-[#1e3a5f] text-base">메뉴 전체보기</h1>
@@ -80,18 +65,15 @@ const menuItemCount = computed(() => menus.value.length);
     </header>
 
     <main class="max-w-[500px] mx-auto pb-8">
-      <!-- Loading Spinner -->
       <div v-if="isLoading" class="flex justify-center items-center h-64">
         <div class="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-[#ff6b4a]"></div>
       </div>
 
-      <!-- Error Message -->
       <div v-else-if="error" class="text-center py-10 px-4">
         <p class="text-red-500 font-semibold mb-4">{{ error }}</p>
         <Button @click="fetchMenus">재시도</Button>
       </div>
-      
-      <!-- Menu Content -->
+
       <template v-else>
         <div class="bg-white px-4 py-3 border-b border-[#e9ecef]">
           <p class="text-sm text-[#495057] leading-relaxed">
@@ -99,38 +81,42 @@ const menuItemCount = computed(() => menus.value.length);
           </p>
         </div>
 
-      <div v-for="category in categories" :key="category" class="px-4 py-5">
-        <h3 class="text-base font-semibold text-[#1e3a5f] mb-4">{{ category }}</h3>
-        <div class="space-y-3">
-          <Card
-              v-for="item in menuItems.filter((mItem) => mItem.category === category)"
+        <div v-if="groupedMenus.length === 0" class="text-center py-10 px-4 text-gray-500">
+          <p>등록된 메뉴 정보가 없습니다.</p>
+        </div>
+
+        <div v-for="group in groupedMenus" :key="group.name" class="px-4 py-5">
+          <h3 class="text-base font-semibold text-[#1e3a5f] mb-4">{{ group.name }}</h3>
+          <div class="space-y-3">
+            <Card
+              v-for="item in group.items"
               :key="item.id"
               class="p-4 border-[#e9ecef] rounded-xl bg-white shadow-card hover:shadow-md transition-shadow"
-          >
-            <div class="flex items-start justify-between gap-3">
-              <div class="flex-1">
-                <h4 class="font-semibold text-[#1e3a5f] mb-1">{{ item.name }}</h4>
-                <p v-if="item.description" class="text-xs text-[#6c757d] mb-2 leading-relaxed">
-                  {{ item.description }}
-                </p>
-                <p class="text-base font-semibold text-[#1e3a5f]">{{ item.price.toLocaleString() }}원</p>
+            >
+              <div class="flex items-start justify-between gap-3">
+                <div class="flex-1">
+                  <h4 class="font-semibold text-[#1e3a5f] mb-1">{{ item.name }}</h4>
+                  <p v-if="item.description" class="text-xs text-[#6c757d] mb-2 leading-relaxed">
+                    {{ item.description }}
+                  </p>
+                  <p class="text-base font-semibold text-[#1e3a5f]">
+                    {{ item.price.toLocaleString() }}원
+                  </p>
+                </div>
+                <div
+                  class="w-20 h-20 rounded-lg border border-[#e9ecef] bg-[#f1f3f5] overflow-hidden flex items-center justify-center text-[10px] text-[#adb5bd]"
+                >
+                  <img
+                    v-if="item.imageUrl"
+                    :src="item.imageUrl"
+                    :alt="`${item.name} 이미지`"
+                    class="w-full h-full object-cover"
+                  />
+                  <span v-else>이미지</span>
+                </div>
               </div>
-              <div
-                class="w-20 h-20 rounded-lg border border-[#e9ecef] bg-[#f1f3f5] overflow-hidden flex items-center justify-center text-[10px] text-[#adb5bd]"
-              >
-                <img
-                  v-if="item.imageUrl"
-                  :src="item.imageUrl"
-                  :alt="`${item.name} 이미지`"
-                  class="w-full h-full object-cover"
-                />
-                <span v-else>이미지</span>
-              </div>
-            </div>
+            </Card>
           </div>
-        </div>
-        <div v-else class="text-center py-10 px-4 text-gray-500">
-          <p>등록된 메뉴 정보가 없습니다.</p>
         </div>
       </template>
     </main>


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 메뉴 상세 페이지를 /api/restaurants/{id}/menus 기반으로 로딩하도록 수정
- 로딩/에러/빈 상태 처리 추가
- 카테고리별 그룹핑 및 메뉴 이미지 칸 유지

## 📁 변경된 파일

- frontend/src/views/restaurant/id/menus/RestaurantMenusPage.vue

