### PR TITLE
feat(withdrawal): 회원 영구 탈퇴 스케쥴러 구현

### DIFF
--- a/src/main/java/com/example/LunchGo/member/repository/OwnerRepository.java
+++ b/src/main/java/com/example/LunchGo/member/repository/OwnerRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface OwnerRepository extends JpaRepository<Owner, Long> {
@@ -51,4 +52,11 @@ public interface OwnerRepository extends JpaRepository<Owner, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Owner o SET o.lastLoginAt = CURRENT_TIMESTAMP WHERE o.ownerId = :ownerId")
     int updateLastLoginAt(@Param("ownerId") Long ownerId);
+
+    /**
+     * Scheduler
+     * */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Owner o WHERE o.status='WITHDRAWAL' AND o.withdrawalAt <=:current")
+    void deleteOwnerComplete(@Param("current") LocalDateTime current);
 }

--- a/src/main/java/com/example/LunchGo/member/repository/UserRepository.java
+++ b/src/main/java/com/example/LunchGo/member/repository/UserRepository.java
@@ -41,6 +41,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("UPDATE User u SET u.lastLoginAt = CURRENT_TIMESTAMP WHERE u.userId = :userId")
     int updateLastLoginAt(@Param("userId") Long userId);
 
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM User u WHERE u.status='WITHDRAWAL' and u.withdrawalAt <= :current")
+    void deleteUserComplete(@Param("current") LocalDateTime current);
+
     /**
      * email로 사용자 정보 뽑아내기 (임직원 등록 시 사용)
      * */

--- a/src/main/java/com/example/LunchGo/member/service/MemberWithdrawalScheduler.java
+++ b/src/main/java/com/example/LunchGo/member/service/MemberWithdrawalScheduler.java
@@ -1,0 +1,31 @@
+package com.example.LunchGo.member.service;
+
+import com.example.LunchGo.member.repository.OwnerRepository;
+import com.example.LunchGo.member.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class MemberWithdrawalScheduler {
+    private final UserRepository userRepository;
+    private final OwnerRepository ownerRepository;
+
+    @Scheduled(cron = "0 2 0 * * *") //매일 오전 12시 2분
+    @Transactional
+    public void deleteWithdrawalMembers() {
+        LocalDateTime threshold = LocalDateTime.now().minusYears(2);
+        //현재 기준 2년전 날짜 계산
+
+        userRepository.deleteUserComplete(threshold); //사용자
+        ownerRepository.deleteOwnerComplete(threshold); //사업자
+
+        log.info("탈퇴 회원 DB 영구 삭제 완료");
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용

- 회원 탈퇴가 가능한 사용자 및 사업자는 회원 탈퇴 이후 2년간 DB에 회원 정보를 보관하다가 2년이 지난후 DB에서 영구 삭제 되어야하는데, 이 영구삭제를 스케쥴러를 이용하여 자동화

## 📁 변경된 파일

- UserRepository.java
- OwnerRepository.java
- MemberWithdrawalScheduler.java

## 🔗 관련 Issue(선택)

- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/349

## ✔️ 체크리스트(선택)

- 스케쥴러 작동은 log로 확인 가능
