### PR TITLE
feat(admin): 관리자의 사업자 승인 로직 구현

### DIFF
--- a/src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
@@ -118,6 +118,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PUT, "/api/admin/forbidden-words/*").hasAuthority("ROLE_ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/admin/forbidden-words/*").hasAuthority("ROLE_ADMIN")
                         .requestMatchers(HttpMethod.PATCH, "/api/admin/reviews/*/blind-requests").hasAuthority("ROLE_ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/admin/list/owner").hasAuthority("ROLE_ADMIN")
                         .anyRequest().authenticated()
                 )
 

--- a/src/main/java/com/example/LunchGo/member/controller/MemberController.java
+++ b/src/main/java/com/example/LunchGo/member/controller/MemberController.java
@@ -73,4 +73,11 @@ public class MemberController {
 
         return new ResponseEntity<>(staffs, HttpStatus.OK);
     }
+    
+    @GetMapping("/admin/list/owner")
+    public ResponseEntity<?> getOwners() {
+        List<OwnerInfo> owners = memberService.getOwners(); //전체 사업자 조회
+        
+        return new ResponseEntity<>(owners, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/LunchGo/member/dto/OwnerInfo.java
+++ b/src/main/java/com/example/LunchGo/member/dto/OwnerInfo.java
@@ -1,5 +1,6 @@
 package com.example.LunchGo.member.dto;
 
+import com.example.LunchGo.member.domain.OwnerStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,4 +19,5 @@ public class OwnerInfo {
     private String businessNum;
     private LocalDate startAt;
     private String image;
+    private OwnerStatus status;
 }

--- a/src/main/java/com/example/LunchGo/member/service/BaseMemberService.java
+++ b/src/main/java/com/example/LunchGo/member/service/BaseMemberService.java
@@ -280,4 +280,17 @@ public class BaseMemberService implements MemberService {
             }
         }
     }
+
+    @Override
+    public List<OwnerInfo> getOwners() {
+        List<Owner> owners = ownerRepository.findAll();
+
+        return owners.stream().map(o -> OwnerInfo.builder()
+                .name(o.getName()).businessNum(o.getBusinessNum())
+                .startAt(o.getStartAt())
+                .loginId(o.getLoginId())
+                .status(o.getStatus())
+                .build()
+        ).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/example/LunchGo/member/service/MemberService.java
+++ b/src/main/java/com/example/LunchGo/member/service/MemberService.java
@@ -44,4 +44,6 @@ public interface MemberService {
     List<StaffInfo> getStaffs(Long ownerId);
 
     void updateLastLoginAt(String userType, Long memberId);
+
+    List<OwnerInfo> getOwners();
 }


### PR DESCRIPTION
## 📌 작업 내용 

- 관리자로 로그인 시, 대기 상태인 사업자를 승인/거절 할 수 있는 사업자 현황 페이지 구현 및 api 연동

## 📁 변경된 파일

- AdminOwnerApprovalPage.vue
- SecurityConfig.java
- MemberController.java
- OwnerInfo.java
- MemberSevice.java

## 🔗 관련 Issue(선택)

- https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/356

## ✔️ 체크리스트(선택)

-리스트 조회 확인
- 승인 및 거절 반영 확인
