### PR TITLE
feat(reservations): 사용자 선주문/선결제 예약 상세 내역에 메뉴 리스트 추가

### DIFF
--- a/frontend/src/views/restaurant/id/confirmation/RestaurantConfirmationPage.vue
+++ b/frontend/src/views/restaurant/id/confirmation/RestaurantConfirmationPage.vue
@@ -37,6 +37,7 @@ const reservation = ref({
     method: '신용카드',
     paidAt: '2024. 12. 10. 14:35',
   },
+  menuItems: [],
 });
 
 const fetchReservationDetail = async () => {
@@ -66,6 +67,7 @@ const fetchReservationDetail = async () => {
         method: data.payment?.method || reservation.value.payment.method,
         paidAt: data.payment?.paidAt || reservation.value.payment.paidAt,
       },
+      menuItems: Array.isArray(data.menuItems) ? data.menuItems : [],
     };
   } catch (error) {
     errorMessage.value = error?.message || '예약 정보를 불러오지 못했습니다.';
@@ -196,6 +198,43 @@ onMounted(async () => {
           <p class="mt-2 text-xs text-[#6c757d] leading-relaxed">
             요청사항은 매장 참고용이며, 예약 변경은 매장으로 직접 문의해 주세요.
           </p>
+        </div>
+      </div>
+
+      <!-- Order Info -->
+      <div
+          v-if="reservation.menuItems && reservation.menuItems.length"
+          class="bg-white px-4 py-5 border-b border-[#e9ecef] mt-2"
+      >
+        <h2 class="text-base font-semibold text-[#1e3a5f] mb-4">주문 내역</h2>
+
+        <div class="divide-y divide-[#e9ecef]">
+          <div
+              v-for="(item, idx) in reservation.menuItems"
+              :key="idx"
+              class="py-4 flex items-center justify-between"
+          >
+            <div class="text-base text-[#495057]">
+              <span class="font-semibold">{{ item.name }}</span>
+              <span class="text-[#6c757d] font-normal"> · {{ item.quantity }}개</span>
+            </div>
+
+            <div class="text-base font-semibold text-[#1e3a5f]">
+              {{ (item.lineAmount ?? (item.unitPrice * item.quantity)).toLocaleString() }}원
+            </div>
+          </div>
+        </div>
+
+        <div class="pt-4 mt-1 border-t border-[#e9ecef] flex items-center justify-between">
+          <span class="text-sm text-[#6c757d]">주문 합계</span>
+
+          <span class="text-lg font-bold text-[#1e3a5f]">
+      {{
+              reservation.menuItems
+                  .reduce((sum, it) => sum + (it.lineAmount ?? (it.unitPrice * it.quantity)), 0)
+                  .toLocaleString()
+            }}원
+    </span>
         </div>
       </div>
 

--- a/src/main/java/com/example/LunchGo/reservation/dto/ReservationConfirmationResponse.java
+++ b/src/main/java/com/example/LunchGo/reservation/dto/ReservationConfirmationResponse.java
@@ -1,5 +1,6 @@
 package com.example.LunchGo.reservation.dto;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,9 @@ public class ReservationConfirmationResponse {
     private RestaurantInfo restaurant;
     private BookingInfo booking;
     private PaymentInfo payment;
+
+    // 주문 내역 (선주문/선결제일 때 내려줌)
+    private List<MenuItem> menuItems;
 
     @Getter
     @Builder
@@ -34,5 +38,14 @@ public class ReservationConfirmationResponse {
         private Integer amount;
         private String method;
         private String paidAt;
+    }
+
+    @Getter
+    @Builder
+    public static class MenuItem {
+        private String name;
+        private Integer quantity;
+        private Integer unitPrice;
+        private Integer lineAmount;
     }
 }

--- a/src/main/java/com/example/LunchGo/reservation/dto/ReservationCreateRequest.java
+++ b/src/main/java/com/example/LunchGo/reservation/dto/ReservationCreateRequest.java
@@ -3,6 +3,7 @@ package com.example.LunchGo.reservation.dto;
 import com.example.LunchGo.reservation.domain.ReservationType;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,6 +24,18 @@ public class ReservationCreateRequest {
     // 선택 입력 (<= 50)
     private String requestMessage;
 
-    // 선주문/선결제 총액
+    // 선주문/선결제 총액(프론트가 보내는 값, 서버는 메뉴 기준으로 재계산 가능)
     private Integer totalAmount;
+
+    /**
+     * 선주문/선결제 시 선택된 메뉴 목록
+     */
+    private List<MenuItem> menuItems;
+
+    @Getter
+    @NoArgsConstructor
+    public static class MenuItem {
+        private Long menuId;
+        private Integer quantity;
+    }
 }

--- a/src/main/java/com/example/LunchGo/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/com/example/LunchGo/reservation/mapper/ReservationMapper.java
@@ -7,6 +7,8 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import java.util.List;
+import com.example.LunchGo.reservation.mapper.row.ReservationMenuItemRow;
 
 @Mapper
 public interface ReservationMapper {
@@ -56,7 +58,18 @@ public interface ReservationMapper {
 
     java.util.List<com.example.LunchGo.reservation.mapper.row.BusinessReservationListRow>
     selectBusinessReservationListByDate(
-            @org.apache.ibatis.annotations.Param("restaurantId") java.lang.Long restaurantId,
-            @org.apache.ibatis.annotations.Param("slotDate") java.time.LocalDate slotDate
+            @Param("restaurantId") java.lang.Long restaurantId,
+            @Param("slotDate") java.time.LocalDate slotDate
     );
+
+    int insertReservationMenuItem(
+            @Param("reservationId") Long reservationId,
+            @Param("menuId") Long menuId,
+            @Param("menuName") String menuName,
+            @Param("unitPrice") Integer unitPrice,
+            @Param("quantity") Integer quantity,
+            @Param("lineAmount") Integer lineAmount
+    );
+
+    List<ReservationMenuItemRow> selectReservationMenuItems(@Param("reservationId") Long reservationId);
 }

--- a/src/main/java/com/example/LunchGo/reservation/mapper/row/ReservationMenuItemRow.java
+++ b/src/main/java/com/example/LunchGo/reservation/mapper/row/ReservationMenuItemRow.java
@@ -1,13 +1,29 @@
 package com.example.LunchGo.reservation.mapper.row;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class ReservationMenuItemRow {
+
+    // 쿼리 alias가 name이든 menuName이든 둘 다 받아먹게
     private String name;
+    private String menuName;
+
     private Integer quantity;
     private Integer unitPrice;
     private Integer lineAmount;
+
+    // BusinessReservationQueryService가 getMenuName()을 호출해도 null 안 나오게 fallback
+    public String getMenuName() {
+        return menuName != null ? menuName : name;
+    }
+
+    // ReservationPaymentService는 getName()을 쓰니까 반대 fallback도 같이
+    public String getName() {
+        return name != null ? name : menuName;
+    }
 }

--- a/src/main/java/com/example/LunchGo/reservation/service/BusinessReservationQueryService.java
+++ b/src/main/java/com/example/LunchGo/reservation/service/BusinessReservationQueryService.java
@@ -8,12 +8,14 @@ import com.example.LunchGo.reservation.entity.Reservation;
 import com.example.LunchGo.reservation.entity.ReservationSlot;
 import com.example.LunchGo.reservation.mapper.ReservationMapper;
 import com.example.LunchGo.reservation.mapper.row.BusinessReservationListRow;
+import com.example.LunchGo.reservation.mapper.row.ReservationMenuItemRow;
 import com.example.LunchGo.reservation.repository.ReservationRepository;
 import com.example.LunchGo.reservation.repository.ReservationSlotRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -69,18 +71,35 @@ public class BusinessReservationQueryService {
                 .orElseThrow(() -> new IllegalArgumentException("user not found: " + reservation.getUserId()));
 
         String status = mapStatus(reservation.getStatus());
-        String paymentType = "PREPAID_CONFIRMED".equals(String.valueOf(reservation.getStatus())) ? "prepaid" : "onsite";
 
+        // 선주문/선결제 여부는 "상태"가 아니라 reservation_type으로 판단해야 안전함
+        boolean isPreorderPrepay = "PREORDER_PREPAY".equalsIgnoreCase(reservation.getReservationType());
+        String paymentType = isPreorderPrepay ? "prepaid" : "onsite";
+
+        // 금액: totalAmount 우선, 없으면 prepayAmount / depositAmount로 fallback
         Integer amount = reservation.getTotalAmount();
         if (amount == null) {
-            // total_amount 없으면 prepay/deposit 중 있는 값으로 표시
-            amount = reservation.getPrepayAmount() != null ? reservation.getPrepayAmount() : reservation.getDepositAmount();
+            amount = (reservation.getPrepayAmount() != null) ? reservation.getPrepayAmount() : reservation.getDepositAmount();
         }
         if (amount == null) amount = 0;
 
+        // 선주문/선결제면 reservation_menu_items에서 가져와서 preorderItems 채우기
+        List<BusinessReservationDetailResponse.PreorderItem> preorderItems = java.util.Collections.emptyList();
+        if (isPreorderPrepay) {
+            List<ReservationMenuItemRow> rows = reservationMapper.selectReservationMenuItems(reservationId);
+            if (rows != null && !rows.isEmpty()) {
+                preorderItems = rows.stream()
+                        .map(r -> BusinessReservationDetailResponse.PreorderItem.builder()
+                                .name(r.getName())
+                                .qty(r.getQuantity())
+                                .price(r.getUnitPrice())
+                                .build())
+                        .toList();
+            }
+        }
+
         return BusinessReservationDetailResponse.builder()
                 .id(reservation.getReservationId())
-                .reservationCode(reservation.getReservationCode())
                 .name(user.getName())
                 .phone(user.getPhone())
                 .date(slot.getSlotDate().toString())
@@ -90,7 +109,7 @@ public class BusinessReservationQueryService {
                 .status(status)
                 .requestNote(reservation.getRequestMessage())
                 .paymentType(paymentType)
-                .preorderItems(Collections.emptyList())
+                .preorderItems(preorderItems)
                 .build();
     }
 

--- a/src/main/java/com/example/LunchGo/reservation/service/ReservationPaymentService.java
+++ b/src/main/java/com/example/LunchGo/reservation/service/ReservationPaymentService.java
@@ -260,6 +260,20 @@ public class ReservationPaymentService {
             .orElseGet(() -> paymentRepository.findTopByReservationIdOrderByCreatedAtDesc(reservationId)
                 .orElse(null));
 
+        List<ReservationMenuItemRow> menuRows = reservationSummaryMapper.selectReservationMenuItems(reservationId);
+        List<ReservationConfirmationResponse.MenuItem> menuItems = new ArrayList<>();
+
+        if (menuRows != null && !menuRows.isEmpty()) {
+            for (ReservationMenuItemRow row : menuRows) {
+                menuItems.add(ReservationConfirmationResponse.MenuItem.builder()
+                        .name(row.getName())
+                        .quantity(row.getQuantity())
+                        .unitPrice(row.getUnitPrice())
+                        .lineAmount(row.getLineAmount())
+                        .build());
+            }
+        }
+
         return ReservationConfirmationResponse.builder()
             .reservationCode(reservation.getReservationCode())
             .restaurant(ReservationConfirmationResponse.RestaurantInfo.builder()
@@ -278,6 +292,7 @@ public class ReservationPaymentService {
                 .method(formatMethod(payment != null ? payment.getMethod() : null))
                 .paidAt(formatPaidAt(payment != null ? payment.getApprovedAt() : null))
                 .build())
+            .menuItems(menuItems.isEmpty() ? null : menuItems)
             .build();
     }
 

--- a/src/main/java/com/example/LunchGo/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/example/LunchGo/reservation/service/ReservationServiceImpl.java
@@ -6,19 +6,21 @@ import com.example.LunchGo.reservation.dto.ReservationCreateRequest;
 import com.example.LunchGo.reservation.dto.ReservationCreateResponse;
 import com.example.LunchGo.reservation.mapper.ReservationMapper;
 import com.example.LunchGo.reservation.mapper.row.ReservationCreateRow;
+import com.example.LunchGo.restaurant.entity.Menu;
+import com.example.LunchGo.restaurant.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
-
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
@@ -33,14 +35,13 @@ public class ReservationServiceImpl implements ReservationService {
     private final ReservationMapper reservationMapper;
     private final ReservationSlotService reservationSlotService;
     private final RedisUtil redisUtil;
-
+    private final MenuRepository menuRepository;
 
     @Override
     @Transactional
     public ReservationCreateResponse create(ReservationCreateRequest request) {
         validate(request);
 
-        // 이 메소드가 끝난 후에도 @Transactional 범위 내에 있으므로 락은 계속 유지(트랜잭션 전파)
         // 지정한 날짜+시간대의 예약슬롯을 불러오는 서비스 로직(없으면 신규 생성)
         ReservationSlot slot = reservationSlotService.getValidatedSlot(
                 request.getRestaurantId(),
@@ -48,6 +49,35 @@ public class ReservationServiceImpl implements ReservationService {
                 request.getSlotTime(),
                 request.getPartySize()
         );
+
+        // PREORDER_PREPAY면 메뉴 스냅샷(이름/가격) 확정 + 합계 계산
+        List<ReservationCreateRequest.MenuItem> reqMenuItems = request.getMenuItems();
+        List<MenuSnapshot> snapshots = new ArrayList<>();
+        Integer preorderSum = null;
+
+        if (ReservationType.PREORDER_PREPAY.equals(request.getReservationType())) {
+            int sum = 0;
+            for (ReservationCreateRequest.MenuItem mi : reqMenuItems) {
+                if (mi == null || mi.getMenuId() == null) {
+                    throw new IllegalArgumentException("menuId is required");
+                }
+                if (mi.getQuantity() == null || mi.getQuantity() <= 0) {
+                    throw new IllegalArgumentException("quantity must be positive");
+                }
+
+                Menu menu = menuRepository
+                        .findByMenuIdAndRestaurantIdAndIsDeletedFalse(mi.getMenuId(), request.getRestaurantId())
+                        .orElseThrow(() -> new IllegalArgumentException("menu not found: " + mi.getMenuId()));
+
+                int unitPrice = menu.getPrice() == null ? 0 : menu.getPrice();
+                int qty = mi.getQuantity();
+                int lineAmount = unitPrice * qty;
+                sum += lineAmount;
+
+                snapshots.add(new MenuSnapshot(menu.getMenuId(), menu.getName(), unitPrice, qty, lineAmount));
+            }
+            preorderSum = sum;
+        }
 
         Reservation reservation = new Reservation();
         reservation.setReservationCode("PENDING");
@@ -61,34 +91,48 @@ public class ReservationServiceImpl implements ReservationService {
 
         if (ReservationType.RESERVATION_DEPOSIT.equals(request.getReservationType())) {
             int perPerson = request.getPartySize() >= DEPOSIT_LARGE_THRESHOLD
-                ? DEPOSIT_PER_PERSON_LARGE
-                : DEPOSIT_PER_PERSON_DEFAULT;
+                    ? DEPOSIT_PER_PERSON_LARGE
+                    : DEPOSIT_PER_PERSON_DEFAULT;
             int depositAmount = perPerson * request.getPartySize();
             reservation.setDepositAmount(depositAmount);
             reservation.setTotalAmount(depositAmount);
         } else if (ReservationType.PREORDER_PREPAY.equals(request.getReservationType())) {
-            reservation.setPrepayAmount(request.getTotalAmount());
-            reservation.setTotalAmount(request.getTotalAmount());
+            // 프론트 totalAmount 대신 "DB 메뉴 합계" 기준으로 저장
+            reservation.setPrepayAmount(preorderSum);
+            reservation.setTotalAmount(preorderSum);
         }
 
         reservationMapper.insertReservation(reservation);
+
+        // reservation_menu_items 저장 (예약 PK 생긴 다음에)
+        if (ReservationType.PREORDER_PREPAY.equals(request.getReservationType()) && !snapshots.isEmpty()) {
+            for (MenuSnapshot s : snapshots) {
+                reservationMapper.insertReservationMenuItem(
+                        reservation.getReservationId(),
+                        s.menuId,
+                        s.menuName,
+                        s.unitPrice,
+                        s.quantity,
+                        s.lineAmount
+                );
+            }
+        }
 
         String code = generateReservationCode(LocalDate.now(), reservation.getReservationId());
         reservationMapper.updateReservationCode(reservation.getReservationId(), code);
 
         ReservationCreateRow row = reservationMapper.selectReservationCreateRow(reservation.getReservationId());
         if (row == null) {
-            // 생성 직후 조회 실패면 데이터 이상이므로 런타임 에러로 바로 터뜨림
             throw new IllegalStateException("created reservation not found");
         }
 
-        //제대로 생성이 된 경우 redis에 응답대기로 방문 확정 관련 상태 넣어놓기
+        // redis에 응답대기로 방문 확정 관련 상태 넣어놓기
         LocalDateTime slotDateTime = LocalDateTime.of(request.getSlotDate(), request.getSlotTime());
-        long ttlMillis = Duration.between(LocalDateTime.now(), slotDateTime).toMillis(); //예약 날짜 - now 만큼 밀리초로 redis에 주입
+        long ttlMillis = Duration.between(LocalDateTime.now(), slotDateTime).toMillis();
         if (ttlMillis < 0) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST); //음수가 나오는 경우 = 과거 시간을 예약한 경우
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
         }
-        redisUtil.setDataExpire(String.valueOf(reservation.getReservationId()), VisitStatus.PENDING.name(),ttlMillis);
+        redisUtil.setDataExpire(String.valueOf(reservation.getReservationId()), VisitStatus.PENDING.name(), ttlMillis);
 
         return new ReservationCreateResponse(
                 row.getReservationId(),
@@ -120,9 +164,14 @@ public class ReservationServiceImpl implements ReservationService {
             throw new IllegalArgumentException("reservationType is required");
         }
 
-        if (ReservationType.PREORDER_PREPAY.equals(request.getReservationType())
-            && (request.getTotalAmount() == null || request.getTotalAmount() <= 0)) {
-            throw new IllegalArgumentException("totalAmount is required for preorder");
+        if (ReservationType.PREORDER_PREPAY.equals(request.getReservationType())) {
+            if (request.getMenuItems() == null || request.getMenuItems().isEmpty()) {
+                throw new IllegalArgumentException("menuItems is required for preorder");
+            }
+            if (request.getTotalAmount() == null || request.getTotalAmount() <= 0) {
+                // 프론트가 보내는 값이지만, 일단 기존 로직 유지 (검증만)
+                throw new IllegalArgumentException("totalAmount is required for preorder");
+            }
         }
 
         if (request.getRequestMessage() != null && request.getRequestMessage().length() > 50) {
@@ -145,5 +194,21 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     public List<LocalTime> slotTimes(Long restaurantId, LocalDate slotDate) {
         return reservationMapper.selectSlotTimesByDate(restaurantId, slotDate);
+    }
+
+    private static class MenuSnapshot {
+        private final Long menuId;
+        private final String menuName;
+        private final Integer unitPrice;
+        private final Integer quantity;
+        private final Integer lineAmount;
+
+        private MenuSnapshot(Long menuId, String menuName, Integer unitPrice, Integer quantity, Integer lineAmount) {
+            this.menuId = menuId;
+            this.menuName = menuName;
+            this.unitPrice = unitPrice;
+            this.quantity = quantity;
+            this.lineAmount = lineAmount;
+        }
     }
 }

--- a/src/main/resources/mapper/ReservationMapper.xml
+++ b/src/main/resources/mapper/ReservationMapper.xml
@@ -220,4 +220,49 @@
         ORDER BY r.created_at DESC
     </select>
 
+    <insert id="insertReservationMenuItem">
+        INSERT INTO reservation_menu_items
+            (reservation_id, menu_id, menu_name, unit_price, quantity, line_amount)
+        VALUES
+            (#{reservationId}, #{menuId}, #{menuName}, #{unitPrice}, #{quantity}, #{lineAmount})
+    </insert>
+
+    <select id="selectReservationMenuItems"
+            resultType="com.example.LunchGo.reservation.mapper.row.ReservationMenuItemRow">
+        SELECT
+            menu_name AS name,
+            quantity,
+            unit_price AS unitPrice,
+            (unit_price * quantity) AS lineAmount
+        FROM reservation_menu_items
+        WHERE reservation_id = #{reservationId}
+          AND is_deleted = 0
+        ORDER BY sort_order ASC
+    </select>
+
+    <select id="selectBusinessReservationListByDate"
+            resultType="com.example.LunchGo.reservation.mapper.row.BusinessReservationListRow">
+        SELECT
+            r.reservation_id AS id,
+            u.name AS name,
+            u.phone AS phone,
+            CONCAT(DATE_FORMAT(s.slot_date, '%Y-%m-%d'), ' ', DATE_FORMAT(s.slot_time, '%H:%i')) AS datetime,
+            r.party_size AS guests,
+            COALESCE(r.total_amount, r.prepay_amount, r.deposit_amount, 0) AS amount,
+            CASE
+                WHEN r.status = 'TEMPORARY' THEN '대기'
+                WHEN r.status IN ('CONFIRMED', 'PREPAID_CONFIRMED') THEN '확정'
+                WHEN r.status = 'CANCELLED' THEN '취소'
+                ELSE '환불'
+                END AS status
+        FROM reservations r
+                 JOIN restaurant_reservation_slots s ON s.slot_id = r.slot_id
+                 JOIN restaurants res ON res.restaurant_id = s.restaurant_id
+                 JOIN users u ON u.user_id = r.user_id
+        WHERE res.restaurant_id = #{restaurantId}
+          AND s.slot_date = #{slotDate}
+        ORDER BY s.slot_time DESC
+    </select>
+
+
 </mapper>


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 사용자 선결제/선주문 으로 예약 했을 때 예약 상세 내역에 메뉴 리스트 추가

## 📁 변경된 파일

- RestaurantConfirmationPage.vue
- MenuSelectionPage.vue
- ReservationConfirmationResponse.java
- ReservationCreateRequest.java
- ReservationMapper.java
- ReservationMenuItemRow.java
- BusinessReservationQueryService.java
- ReservationPaymentService.java
- ReservationServiceImpl.java
- ReservationMapper.xml

## 공유사항 to 리뷰어 <!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요.-->

## 🔗 관련 Issue(선택)

-

## ✔️ 체크리스트(선택)

- ex) 테스트 통과 확인
