### PR TITLE
feat: 날씨 기반 추천 기능 추가

### DIFF
--- a/frontend/src/composables/useHomeRecommendations.js
+++ b/frontend/src/composables/useHomeRecommendations.js
@@ -7,6 +7,8 @@ export const useHomeRecommendations = ({
   filterPerPersonBudget,
   fetchBudgetRecommendations,
   clearBudgetRecommendations,
+  fetchWeatherRecommendations,
+  clearWeatherRecommendations,
   fetchTagMappingRecommendations,
   clearTagMappingRecommendations,
   clearTrendingRestaurants,
@@ -22,6 +24,7 @@ export const useHomeRecommendations = ({
   RECOMMEND_CAFETERIA,
   RECOMMEND_BUDGET,
   RECOMMEND_TASTE,
+  RECOMMEND_WEATHER,
 }) => {
   const applyFilters = () => {
     selectedSort.value = filterForm.sort || sortOptions[0];
@@ -31,6 +34,11 @@ export const useHomeRecommendations = ({
       fetchBudgetRecommendations(filterPerPersonBudget.value);
     } else {
       clearBudgetRecommendations();
+    }
+    if (selectedRecommendation.value === RECOMMEND_WEATHER) {
+      fetchWeatherRecommendations();
+    } else {
+      clearWeatherRecommendations();
     }
     if (selectedRecommendation.value === RECOMMEND_TASTE) {
       fetchTagMappingRecommendations();

--- a/frontend/src/composables/useWeatherRecommendation.js
+++ b/frontend/src/composables/useWeatherRecommendation.js
@@ -1,0 +1,165 @@
+import { ref } from "vue";
+import httpRequest from "@/router/httpRequest.js";
+import { restaurants as restaurantData } from "@/data/restaurants";
+
+const normalizeTag = (tag) => {
+  if (!tag) return "";
+  if (typeof tag === "string") return tag;
+  if (tag.name) return tag.name;
+  if (tag.content) return tag.content;
+  return String(tag);
+};
+
+const extractRestaurantTags = (restaurant) => {
+  const sources = [
+    restaurant?.restaurantTags,
+    restaurant?.tags,
+    restaurant?.topTags,
+  ];
+  return sources
+    .flatMap((tags) => tags || [])
+    .map(normalizeTag)
+    .map((value) => value.trim())
+    .filter(Boolean);
+};
+
+const normalizeWeatherPayload = (payload) => {
+  if (!payload) return null;
+  const data = payload.data ?? payload;
+  if (!data || typeof data !== "object") return null;
+  return {
+    temp: typeof data.temp === "number" ? data.temp : Number(data.temp),
+    feelsLike:
+      typeof data.feelsLike === "number" ? data.feelsLike : Number(data.feelsLike),
+    condition: data.condition || "",
+    description: data.description || "",
+  };
+};
+
+const resolveWeatherProfile = (weather) => {
+  if (!weather) return null;
+  const condition = String(weather.condition || "").toLowerCase();
+  const temp = Number.isFinite(weather.temp)
+    ? weather.temp
+    : weather.feelsLike;
+
+  if (["rain", "drizzle", "thunderstorm"].includes(condition)) {
+    return "rain";
+  }
+  if (condition === "snow") {
+    return "snow";
+  }
+  if (Number.isFinite(temp) && temp >= 28) return "hot";
+  if (Number.isFinite(temp) && temp <= 7) return "cold";
+  return "mild";
+};
+
+const weatherKeywords = {
+  rain: ["국물", "찌개", "전골", "칼국수", "우동", "짬뽕", "수제비"],
+  snow: ["국물", "탕", "전골", "보양", "뜨끈", "곰탕", "설렁탕", "갈비탕"],
+  hot: ["냉면", "소바", "빙수", "샐러드", "회", "초밥", "시원", "냉"],
+  cold: ["국", "탕", "찌개", "전골", "칼국수", "우동", "라면", "뜨끈", "따뜻"],
+  mild: ["가벼운", "정식", "한식", "분식", "파스타", "덮밥", "샌드위치"],
+};
+
+const buildRestaurantText = (restaurant) => {
+  const menus = restaurant?.menus || [];
+  const menuText = menus
+    .map((menu) => [menu?.name, menu?.description].filter(Boolean).join(" "))
+    .join(" ");
+  return [
+    restaurant?.name,
+    restaurant?.category,
+    restaurant?.tagline,
+    restaurant?.description,
+    menuText,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+};
+
+const scoreRestaurant = (restaurant, keywords) => {
+  const tagList = extractRestaurantTags(restaurant).map((tag) =>
+    tag.toLowerCase()
+  );
+  const text = buildRestaurantText(restaurant);
+
+  let score = 0;
+  keywords.forEach((keyword) => {
+    const lowered = keyword.toLowerCase();
+    if (tagList.some((tag) => tag.includes(lowered))) {
+      score += 2;
+    }
+    if (text.includes(lowered)) {
+      score += 1;
+    }
+  });
+  return score;
+};
+
+export const useWeatherRecommendation = () => {
+  const isWeatherLoading = ref(false);
+  const weatherRecommendations = ref([]);
+  const weatherError = ref(null);
+  const weatherSummary = ref(null);
+
+  const fetchWeatherRecommendations = async (coords) => {
+    if (!coords || !Number.isFinite(coords.lat) || !Number.isFinite(coords.lng)) {
+      weatherRecommendations.value = [];
+      weatherSummary.value = null;
+      weatherError.value = "위치 정보가 유효하지 않습니다.";
+      return;
+    }
+
+    isWeatherLoading.value = true;
+    weatherError.value = null;
+
+    try {
+      const response = await httpRequest.get("/api/weather/current", {
+        lat: coords.lat,
+        lon: coords.lng,
+      });
+      const weather = normalizeWeatherPayload(response?.data);
+      if (!weather) {
+        throw new Error("invalid-weather-response");
+      }
+
+      weatherSummary.value = weather;
+      const profile = resolveWeatherProfile(weather);
+      const keywords = weatherKeywords[profile] || [];
+      const scored = restaurantData
+        .map((restaurant) => ({
+          restaurant,
+          score: scoreRestaurant(restaurant, keywords),
+        }))
+        .filter((item) => item.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .map((item) => item.restaurant);
+
+      weatherRecommendations.value = scored.length ? scored : restaurantData;
+    } catch (error) {
+      console.error("날씨 추천 실패:", error);
+      weatherRecommendations.value = [];
+      weatherSummary.value = null;
+      weatherError.value = "날씨 정보를 가져오지 못했습니다.";
+    } finally {
+      isWeatherLoading.value = false;
+    }
+  };
+
+  const clearWeatherRecommendations = () => {
+    weatherRecommendations.value = [];
+    weatherSummary.value = null;
+    weatherError.value = null;
+  };
+
+  return {
+    isWeatherLoading,
+    weatherRecommendations,
+    weatherError,
+    weatherSummary,
+    fetchWeatherRecommendations,
+    clearWeatherRecommendations,
+  };
+};

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -36,6 +36,7 @@ import TrendingRecommendationSection from "@/components/ui/TrendingRecommendatio
 import { useTrendingRestaurants } from "@/composables/useTrendingRestaurants";
 import { useBudgetRecommendation, extractPriceValue } from "@/composables/useBudgetRecommendation";
 import { useTagMappingRecommendation } from "@/composables/useTagMappingRecommendation";
+import { useWeatherRecommendation } from "@/composables/useWeatherRecommendation";
 import { useHomeRecommendations } from "@/composables/useHomeRecommendations";
 import { useAccountStore } from "@/stores/account";
 import { useFavorites } from "@/composables/useFavorites";
@@ -225,6 +226,14 @@ const {
   fetchTagMappingRecommendations,
   clearTagMappingRecommendations,
 } = useTagMappingRecommendation();
+const {
+  isWeatherLoading,
+  weatherRecommendations,
+  weatherError,
+  weatherSummary,
+  fetchWeatherRecommendations,
+  clearWeatherRecommendations,
+} = useWeatherRecommendation();
 const isGeocodeExportMode = ref(false);
 const isGeocodeExporting = ref(false);
 const geocodeExportProgress = ref({ done: 0, total: 0 });
@@ -253,6 +262,9 @@ const restaurants = restaurantData;
 const baseRestaurants = computed(() => {
   if (selectedRecommendation.value === RECOMMEND_BUDGET) {
     return budgetRecommendations.value;
+  }
+  if (selectedRecommendation.value === RECOMMEND_WEATHER) {
+    return weatherRecommendations.value;
   }
   if (selectedRecommendation.value === RECOMMEND_TASTE) {
     return tagMappingRecommendations.value;
@@ -1238,6 +1250,7 @@ const resetFilters = () => {
   filterBudget.value = 60000;
   filterPartySize.value = 4;
   clearBudgetRecommendations();
+  clearWeatherRecommendations();
   clearTagMappingRecommendations();
 };
 
@@ -1248,6 +1261,7 @@ const closeFilterModal = () => {
   selectedRecommendation.value = null;
   clearTrendingRestaurants();
   clearTagMappingRecommendations();
+  clearWeatherRecommendations();
   currentPage.value = 1;
   isFilterOpen.value = false;
   persistHomeListState();
@@ -1348,6 +1362,9 @@ onMounted(() => {
         selectedRecommendation.value = null;
         clearBudgetRecommendations();
       }
+      if (selectedRecommendation.value === RECOMMEND_WEATHER) {
+        fetchWeatherRecommendationsForCenter();
+      }
       nextTick(() => {
         if (Number.isFinite(parsed.scrollY)) {
           window.scrollTo(0, parsed.scrollY);
@@ -1390,6 +1407,9 @@ const handleClearCafeteriaRecommendations = () => {
   }
 };
 
+const fetchWeatherRecommendationsForCenter = () =>
+    fetchWeatherRecommendations(mapCenter.value);
+
 const {
   applyFilters,
   clearTrendingRecommendation,
@@ -1405,6 +1425,8 @@ const {
   filterPerPersonBudget,
   fetchBudgetRecommendations,
   clearBudgetRecommendations,
+  fetchWeatherRecommendations: fetchWeatherRecommendationsForCenter,
+  clearWeatherRecommendations,
   fetchTagMappingRecommendations,
   clearTagMappingRecommendations,
   clearTrendingRestaurants,
@@ -1420,6 +1442,7 @@ const {
   RECOMMEND_CAFETERIA,
   RECOMMEND_BUDGET,
   RECOMMEND_TASTE,
+  RECOMMEND_WEATHER,
 });
 
 watch([selectedSort, selectedPriceRange, selectedRecommendation], () => {

--- a/src/main/java/com/example/LunchGo/weather/controller/WeatherController.java
+++ b/src/main/java/com/example/LunchGo/weather/controller/WeatherController.java
@@ -1,0 +1,24 @@
+package com.example.LunchGo.weather.controller;
+
+import com.example.LunchGo.weather.dto.WeatherResponse;
+import com.example.LunchGo.weather.service.WeatherService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/weather")
+public class WeatherController {
+    private final WeatherService weatherService;
+
+    @GetMapping("/current")
+    public WeatherResponse getCurrentWeather(
+        @RequestParam("lat") double lat,
+        @RequestParam("lon") double lon
+    ) {
+        return weatherService.fetchCurrentWeather(lat, lon);
+    }
+}

--- a/src/main/java/com/example/LunchGo/weather/dto/WeatherResponse.java
+++ b/src/main/java/com/example/LunchGo/weather/dto/WeatherResponse.java
@@ -1,0 +1,13 @@
+package com.example.LunchGo.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WeatherResponse {
+    private Double temp;
+    private Double feelsLike;
+    private String condition;
+    private String description;
+}

--- a/src/main/java/com/example/LunchGo/weather/service/WeatherService.java
+++ b/src/main/java/com/example/LunchGo/weather/service/WeatherService.java
@@ -1,0 +1,88 @@
+package com.example.LunchGo.weather.service;
+
+import com.example.LunchGo.weather.dto.WeatherResponse;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class WeatherService {
+    private final RestTemplateBuilder restTemplateBuilder;
+
+    @Value("${weather.openweather.base-url:https://api.openweathermap.org}")
+    private String apiBase;
+
+    @Value("${weather.openweather.api-key:}")
+    private String apiKey;
+
+    public WeatherResponse fetchCurrentWeather(double lat, double lon) {
+        if (!StringUtils.hasText(apiKey)) {
+            throw new IllegalStateException("OpenWeather API Key가 설정되지 않았습니다.");
+        }
+
+        String url =
+            apiBase
+                + "/data/2.5/weather?lat="
+                + lat
+                + "&lon="
+                + lon
+                + "&appid="
+                + apiKey
+                + "&units=metric&lang=kr";
+
+        RestTemplate restTemplate = restTemplateBuilder.build();
+        ResponseEntity<Map> response = restTemplate.getForEntity(url, Map.class);
+        Map body = response.getBody();
+        if (body == null) {
+            throw new IllegalStateException("OpenWeather 응답이 비어있습니다.");
+        }
+
+        Map main = castMap(body.get("main"));
+        Double temp = numberValue(main != null ? main.get("temp") : null);
+        Double feelsLike = numberValue(main != null ? main.get("feels_like") : null);
+
+        Map weather = null;
+        Object weatherObj = body.get("weather");
+        if (weatherObj instanceof List) {
+            List list = (List) weatherObj;
+            if (!list.isEmpty() && list.get(0) instanceof Map) {
+                weather = (Map) list.get(0);
+            }
+        }
+
+        String condition = stringValue(weather != null ? weather.get("main") : null);
+        String description = stringValue(weather != null ? weather.get("description") : null);
+
+        return new WeatherResponse(temp, feelsLike, condition, description);
+    }
+
+    private String stringValue(Object value) {
+        return value != null ? String.valueOf(value) : null;
+    }
+
+    private Double numberValue(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Double.parseDouble((String) value);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map castMap(Object value) {
+        return value instanceof Map ? (Map) value : null;
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- OpenWeather 프록시 API 추가(/api/weather/current) 및 응답 정규화
- 홈 화면 날씨 추천 흐름 연동
- 날씨 분류를 비/눈/더움/추움/기타로 세분화하고 키워드 매핑 적용
- OpenWeather 키 설정용 property 추가

## 📁 변경된 파일
- frontend/src/composables/useWeatherRecommendation.js
- frontend/src/composables/useHomeRecommendations.js
- frontend/src/views/HomeView.vue
- src/main/java/com/example/LunchGo/weather/controller/WeatherController.java
- src/main/java/com/example/LunchGo/weather/service/WeatherService.java
- src/main/java/com/example/LunchGo/weather/dto/WeatherResponse.java


