### PR TITLE
feat(search): 식당 검색 기능 중 일부(예약 날짜, 시간대, 인원수) 기능 추가

### DIFF
--- a/frontend/src/data/restaurants.js
+++ b/frontend/src/data/restaurants.js
@@ -4095,7 +4095,7 @@ export const restaurants = [
     ],
   },
   {
-    id: '107',
+    id: '109',
     name: '팔복판교',
     category: '기타',
     rating: 0,

--- a/src/main/java/com/example/LunchGo/common/config/MyBatisMapperConfig.java
+++ b/src/main/java/com/example/LunchGo/common/config/MyBatisMapperConfig.java
@@ -7,7 +7,8 @@ import org.springframework.context.annotation.Configuration;
 @MapperScan(basePackages = {
         "com.example.LunchGo.review.mapper",
         "com.example.LunchGo.member.mapper",
-        "com.example.LunchGo.reservation.mapper"
+        "com.example.LunchGo.reservation.mapper",
+        "com.example.LunchGo.restaurant.mapper"
 })
 public class MyBatisMapperConfig {
 }

--- a/src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
@@ -57,7 +57,8 @@ public class SecurityConfig {
 
                         .requestMatchers(HttpMethod.GET,
                                 "/api/restaurants/{id}",
-                                "/api/restaurants/*/menus"
+                                "/api/restaurants/*/menus",
+                                "/api/restaurants/search"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET,
                                 "/api/restaurants/*/reviews",

--- a/src/main/java/com/example/LunchGo/restaurant/controller/PublicRestaurantController.java
+++ b/src/main/java/com/example/LunchGo/restaurant/controller/PublicRestaurantController.java
@@ -1,15 +1,20 @@
 package com.example.LunchGo.restaurant.controller;
 
 import com.example.LunchGo.restaurant.dto.RestaurantDetailResponse;
+import com.example.LunchGo.restaurant.dto.RestaurantSearchParameter;
 import com.example.LunchGo.restaurant.service.PublicRestaurantService;
+import com.example.LunchGo.restaurant.service.RestaurantSearchService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/restaurants")
@@ -17,6 +22,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class PublicRestaurantController {
 
     private final PublicRestaurantService publicRestaurantService;
+    private final RestaurantSearchService restaurantSearchService;
+
+    @GetMapping("/search")
+    public ResponseEntity<List<Long>> searchRestaurants(
+            @ModelAttribute RestaurantSearchParameter params
+    ) {
+        List<Long> restaurantIds = restaurantSearchService.searchRestaurants(params);
+
+        if (restaurantIds.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        return ResponseEntity.ok(restaurantIds);
+    }
 
     @GetMapping("/{id}")
     public ResponseEntity<RestaurantDetailResponse> getRestaurantDetail(

--- a/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantSearchParameter.java
+++ b/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantSearchParameter.java
@@ -9,5 +9,5 @@ public class RestaurantSearchParameter {
     private LocalDate date;
     private LocalTime time;
     private Integer partySize;
-    // TODO: 향후 태그 검색 기능 추가 시, 여기에 List<String> tags; 필드 추가
+    // TODO: 향후 태그 검색 기능 추가 시, 여기에 필드 추가
 }

--- a/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantSearchParameter.java
+++ b/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantSearchParameter.java
@@ -2,12 +2,12 @@ package com.example.LunchGo.restaurant.dto;
 
 import lombok.Data;
 import java.time.LocalDate;
-import java.util.List; // List import 추가
+import java.time.LocalTime;
 
 @Data
 public class RestaurantSearchParameter {
     private LocalDate date;
-    private String time;
+    private LocalTime time;
     private Integer partySize;
     // TODO: 향후 태그 검색 기능 추가 시, 여기에 List<String> tags; 필드 추가
 }

--- a/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantSearchParameter.java
+++ b/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantSearchParameter.java
@@ -1,0 +1,13 @@
+package com.example.LunchGo.restaurant.dto;
+
+import lombok.Data;
+import java.time.LocalDate;
+import java.util.List; // List import 추가
+
+@Data
+public class RestaurantSearchParameter {
+    private LocalDate date;
+    private String time;
+    private Integer partySize;
+    // TODO: 향후 태그 검색 기능 추가 시, 여기에 List<String> tags; 필드 추가
+}

--- a/src/main/java/com/example/LunchGo/restaurant/mapper/RestaurantSearchMapper.java
+++ b/src/main/java/com/example/LunchGo/restaurant/mapper/RestaurantSearchMapper.java
@@ -1,0 +1,12 @@
+package com.example.LunchGo.restaurant.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import com.example.LunchGo.restaurant.dto.RestaurantSearchParameter;
+
+import java.util.List;
+
+@Mapper
+public interface RestaurantSearchMapper {
+
+    List<Long> findAvailableRestaurantIds(RestaurantSearchParameter params);
+}

--- a/src/main/java/com/example/LunchGo/restaurant/service/RestaurantSearchService.java
+++ b/src/main/java/com/example/LunchGo/restaurant/service/RestaurantSearchService.java
@@ -1,0 +1,39 @@
+package com.example.LunchGo.restaurant.service;
+
+import com.example.LunchGo.restaurant.dto.RestaurantSearchParameter;
+import com.example.LunchGo.restaurant.mapper.RestaurantSearchMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RestaurantSearchService {
+
+    private final RestaurantSearchMapper restaurantSearchMapper;
+
+    /**
+     * 검색 파라미터를 기반으로 예약 가능한 식당 ID 목록을 조회합니다.
+     * @param params 검색 파라미터 (날짜, 시간, 인원수 등)
+     * @return 검색 조건에 맞는 식당 ID 목록
+     */
+    public List<Long> searchRestaurants(RestaurantSearchParameter params) {
+        // 1. MyBatis Mapper를 호출하여 조건에 맞는 식당 ID 목록을 조회합니다.
+        List<Long> restaurantIds = restaurantSearchMapper.findAvailableRestaurantIds(params);
+
+        // 2. 조회된 ID 목록이 없으면, 빈 리스트를 반환합니다.
+        if (CollectionUtils.isEmpty(restaurantIds)) {
+            return Collections.emptyList();
+        }
+
+        // 3. 조회된 식당 ID 목록을 반환합니다.
+        return restaurantIds;
+    }
+}
+
+

--- a/src/main/resources/mapper/RestaurantSearchMapper.xml
+++ b/src/main/resources/mapper/RestaurantSearchMapper.xml
@@ -8,15 +8,22 @@
         -- 지정한 날짜, 시간대, 식당ID로 생성된 예약 슬롯들을 확인(없으면 null)
         LEFT JOIN restaurant_reservation_slots s
             ON r.restaurant_id = s.restaurant_id
-            <if test="date != null">
-                AND s.slot_date = #{date}
-            </if>
-            <if test="date == null">
-                AND s.slot_date BETWEEN date_add(curdate(), interval -7 day) and date_add(curdate(), interval 7 day)
-            </if>
-            <if test="time != null">
-                AND s.slot_time = #{time}
-            </if>
+            <choose>
+                <when test="date != null">
+                    AND s.slot_date = #{date}
+                </when>
+                <otherwise>
+                    AND s.slot_date BETWEEN date_add(curdate(), interval -7 day) and date_add(curdate(), interval 7 day)
+                </otherwise>
+            </choose>
+            <choose>
+                <when test="time != null">
+                    AND s.slot_time = #{time} AND s.slot_time BETWEEN r.open_time and r.close_time
+                </when>
+                <otherwise>
+                    AND s.slot_time IN ('11:00:00', '12:00:00', '13:00:00', '14:00:00')
+                </otherwise>
+            </choose>
         -- 지정한 날짜, 시간대, 식당ID로 생성된 예약 슬롯들을 확인(없으면 null)
         LEFT JOIN (
             -- 지정한 날짜, 시간대에 특정 식당을 예약한 인원수 총합 계산

--- a/src/main/resources/mapper/RestaurantSearchMapper.xml
+++ b/src/main/resources/mapper/RestaurantSearchMapper.xml
@@ -11,6 +11,9 @@
             <if test="date != null">
                 AND s.slot_date = #{date}
             </if>
+            <if test="date == null">
+                AND s.slot_date BETWEEN date_add(curdate(), interval -7 day) and date_add(curdate(), interval 7 day)
+            </if>
             <if test="time != null">
                 AND s.slot_time = #{time}
             </if>
@@ -30,6 +33,7 @@
                 -- Case 2: 예약 슬롯이 존재하지만 잔여석이 충분함
                 s.max_capacity >= (IFNULL(res.total_party_size, 0) + #{partySize})
             )
+            <!-- 검색 기능 확장 시 여기에 <if> 태그를 사용하여 추가 검색 조건을 작성하세요. -->
         </where>
     </select>
 

--- a/src/main/resources/mapper/RestaurantSearchMapper.xml
+++ b/src/main/resources/mapper/RestaurantSearchMapper.xml
@@ -3,43 +3,33 @@
 <mapper namespace="com.example.LunchGo.restaurant.mapper.RestaurantSearchMapper">
 
     <select id="findAvailableRestaurantIds" parameterType="com.example.LunchGo.restaurant.dto.RestaurantSearchParameter" resultType="long">
-        SELECT DISTINCT r.id
+        SELECT DISTINCT r.restaurant_id
         FROM restaurants r
-
-        <!-- 날짜/시간 검색이 있을 경우에만 예약 가능 여부 판별을 위해 JOIN -->
-        <if test="date != null and time != null and time != ''">
-            LEFT JOIN restaurant_reservation_slots rrs
-            ON r.id = rrs.restaurant_id
-            AND rrs.slot_date = #{date}
-            AND rrs.slot_time = #{time}
-        </if>
-
-        <!-- TODO: 태그 검색 기능 추가 시, 여기에 INNER JOIN 구문 추가 -->
-
-
-        <where>
-            <!-- TODO: 태그 검색 기능 추가 시, 여기에 AND 조건으로 태그 필터링 구문 추가 -->
-
-
-            <!-- 날짜/시간/인원수에 따른 예약 가능 여부 필터링 조건 -->
-            <if test="date != null and time != null and time != ''">
-                AND (
-                    -- 1. 식당의 일반적인 운영 시간 확인
-                    (#{time} BETWEEN r.open_time AND r.close_time)
-                    AND
-                    -- 시나리오 1: 해당 날짜/시간에 예약 슬롯이 아예 없는 경우
-                    (rrs.slot_id IS NULL OR
-                        -- 시나리오 2: 해당 날짜/시간에 예약 슬롯이 있지만 잔여석이 충분한 경우
-                        (rrs.slot_id IS NOT NULL AND r.reservation_limit >= (
-                            -- `sumPartySizeBySlotId`의 로직을 서브쿼리로 구현
-                            SELECT COALESCE(SUM(res.party_size), 0)
-                            FROM reservations res
-                            WHERE res.slot_id = rrs.slot_id
-                            AND res.status IN ('TEMPORARY', 'CONFIRMED', 'PREPAID_CONFIRM')
-                        ) + #{partySize})
-                    )
-                )
+        -- 지정한 날짜, 시간대, 식당ID로 생성된 예약 슬롯들을 확인(없으면 null)
+        LEFT JOIN restaurant_reservation_slots s
+            ON r.restaurant_id = s.restaurant_id
+            <if test="date != null">
+                AND s.slot_date = #{date}
             </if>
+            <if test="time != null">
+                AND s.slot_time = #{time}
+            </if>
+        -- 지정한 날짜, 시간대, 식당ID로 생성된 예약 슬롯들을 확인(없으면 null)
+        LEFT JOIN (
+            -- 지정한 날짜, 시간대에 특정 식당을 예약한 인원수 총합 계산
+            SELECT slot_id, COALESCE(SUM(party_size), 0) as total_party_size
+            FROM reservations
+            WHERE status IN ('TEMPORARY', 'CONFIRMED', 'PREPAID_CONFIRM')
+            GROUP BY slot_id
+        ) res ON s.slot_id = res.slot_id
+        <where>
+            AND (
+                -- Case 1: 특정 식당에 관한 예약 슬롯이 추가된 적이 없음
+                s.slot_id IS NULL
+                OR
+                -- Case 2: 예약 슬롯이 존재하지만 잔여석이 충분함
+                s.max_capacity >= (IFNULL(res.total_party_size, 0) + #{partySize})
+            )
         </where>
     </select>
 

--- a/src/main/resources/mapper/RestaurantSearchMapper.xml
+++ b/src/main/resources/mapper/RestaurantSearchMapper.xml
@@ -24,7 +24,6 @@
                     AND s.slot_time IN ('11:00:00', '12:00:00', '13:00:00', '14:00:00')
                 </otherwise>
             </choose>
-        -- 지정한 날짜, 시간대, 식당ID로 생성된 예약 슬롯들을 확인(없으면 null)
         LEFT JOIN (
             -- 지정한 날짜, 시간대에 특정 식당을 예약한 인원수 총합 계산
             SELECT slot_id, COALESCE(SUM(party_size), 0) as total_party_size
@@ -33,6 +32,7 @@
             GROUP BY slot_id
         ) res ON s.slot_id = res.slot_id
         <where>
+            r.status = 'OPENED'
             AND (
                 -- Case 1: 특정 식당에 관한 예약 슬롯이 추가된 적이 없음
                 s.slot_id IS NULL

--- a/src/main/resources/mapper/RestaurantSearchMapper.xml
+++ b/src/main/resources/mapper/RestaurantSearchMapper.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.LunchGo.restaurant.mapper.RestaurantSearchMapper">
+
+    <select id="findAvailableRestaurantIds" parameterType="com.example.LunchGo.restaurant.dto.RestaurantSearchParameter" resultType="long">
+        SELECT DISTINCT r.id
+        FROM restaurants r
+
+        <!-- 날짜/시간 검색이 있을 경우에만 예약 가능 여부 판별을 위해 JOIN -->
+        <if test="date != null and time != null and time != ''">
+            LEFT JOIN restaurant_reservation_slots rrs
+            ON r.id = rrs.restaurant_id
+            AND rrs.slot_date = #{date}
+            AND rrs.slot_time = #{time}
+        </if>
+
+        <!-- TODO: 태그 검색 기능 추가 시, 여기에 INNER JOIN 구문 추가 -->
+
+
+        <where>
+            <!-- TODO: 태그 검색 기능 추가 시, 여기에 AND 조건으로 태그 필터링 구문 추가 -->
+
+
+            <!-- 날짜/시간/인원수에 따른 예약 가능 여부 필터링 조건 -->
+            <if test="date != null and time != null and time != ''">
+                AND (
+                    -- 1. 식당의 일반적인 운영 시간 확인
+                    (#{time} BETWEEN r.open_time AND r.close_time)
+                    AND
+                    -- 시나리오 1: 해당 날짜/시간에 예약 슬롯이 아예 없는 경우
+                    (rrs.slot_id IS NULL OR
+                        -- 시나리오 2: 해당 날짜/시간에 예약 슬롯이 있지만 잔여석이 충분한 경우
+                        (rrs.slot_id IS NOT NULL AND r.reservation_limit >= (
+                            -- `sumPartySizeBySlotId`의 로직을 서브쿼리로 구현
+                            SELECT COALESCE(SUM(res.party_size), 0)
+                            FROM reservations res
+                            WHERE res.slot_id = rrs.slot_id
+                            AND res.status IN ('TEMPORARY', 'CONFIRMED', 'PREPAID_CONFIRM')
+                        ) + #{partySize})
+                    )
+                )
+            </if>
+        </where>
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 식당 검색 기능 관련 백엔드 로직 추가
  - 검색 필터를 사용한 식당 검색 기능 중, 선택한 예약 날짜, 시간대, 인원수로 예약 가능한 식당을 검색하는 기능 추가
  - 현재는 백엔드 로직만 추가, 프론트엔드에서의 적용은 PR 승인 이후 추가 예정
- restaurants.js 파일 관련 오타 수정

## 📁 변경된 파일

- frontend/src/data/restaurants.js
- src/main/java/com/example/LunchGo/common/config/MyBatisMapperConfig.java
- src/main/java/com/example/LunchGo/common/config/SecurityConfig.java
- src/main/java/com/example/LunchGo/restaurant/controller/PublicRestaurantController.java
- src/main/java/com/example/LunchGo/restaurant/dto/RestaurantSearchParameter.java
- src/main/java/com/example/LunchGo/restaurant/mapper/RestaurantSearchMapper.java
- src/main/java/com/example/LunchGo/restaurant/service/RestaurantSearchService.java
- src/main/resources/mapper/RestaurantSearchMapper.xml


## 공유사항 to 리뷰어 <!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요.-->

- 검색 기능에 관한 백엔드 로직에서는 지정한 조건에 맞는 식당의 id 리스트를 반환받고, 프론트의 HomeView.vue 파일에서 이 리스트에 해당하는 id를 갖는 식당만 필터링하는 방식으로 검색 결과를 출력합니다.
- 검색필터를 사용한 검색 기능에 태그 매핑 기능을 추가하여 확장하기 위한 작업에 관한 주석을 mapper, dto에 추가했습니다.

## 🔗 관련 Issue(선택)

- [[FEATURE] 날짜, 시간대, 인원수 기준 검색 기능 추가 #338
](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/338)

## ✔️ 체크리스트(선택)

- 지정한 날짜, 시간대, 인원수로 예약을 받을 수 있는 식당들의 id만 반환되는지 확인
(restaurant_id=3인 식당에 관한 2025년 12월 24일 13시 예약에 관한 슬롯에서는 검색필터에서 지정한 인원수를 더 이상 수용할 수 없으므로, restaurant_id=3인 식당은 검색 결과에서 제외됨)

<img width="1500" height="900" alt="image" src="https://github.com/user-attachments/assets/cb9d0a3a-6bd3-4d4a-bdcf-1c7e5ef7d7a5" />
