### PR TITLE
feat(search): 선주문/선결제 허용 식당 검색 기능 추가

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -143,6 +143,7 @@ const searchDate = ref("");
 const searchTime = ref("");
 const searchCategories = ref([]);
 const searchPartySize = ref(4);
+const searchPreorder = ref(false);
 const searchTags = ref([]);
 const avoidIngredients = ref([]);
 const searchDistance = ref("");
@@ -1340,6 +1341,7 @@ const resetSearch = () => {
   searchTime.value = "";
   searchCategories.value = [];
   searchPartySize.value = 4;
+  searchPreorder.value = false;
   searchTags.value = [];
   avoidIngredients.value = [];
   searchDistance.value = "";
@@ -1354,6 +1356,7 @@ const applySearch = async () => {
       date: searchDate.value || null,
       time: searchTime.value || null,
       partySize: searchPartySize.value,
+      preorderAvailable: searchPreorder.value,
       // TODO: 향후 태그, 카테고리 등 추가 검색 필터 파라미터 확장 가능
     };
     const response = await httpRequest.get("/api/restaurants/search", params);
@@ -2130,6 +2133,25 @@ onBeforeUnmount(() => {
                 <Plus class="w-4 h-4 text-gray-700" />
               </button>
             </div>
+          </div>
+
+          <!-- Pre-order/Pre-payment -->
+          <div class="flex items-center justify-between">
+            <h4 class="text-sm font-semibold text-[#1e3a5f]">선주문/선결제 가능 식당</h4>
+            <button
+                @click="searchPreorder = !searchPreorder"
+                :class="[
+                'relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[#ff6b4a] focus:ring-offset-2',
+                searchPreorder ? 'bg-[#ff6b4a]' : 'bg-gray-200',
+              ]"
+            >
+              <span
+                  :class="[
+                  'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+                  searchPreorder ? 'translate-x-6' : 'translate-x-1',
+                ]"
+              />
+            </button>
           </div>
 
           <!-- Distance Filter -->

--- a/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantSearchParameter.java
+++ b/src/main/java/com/example/LunchGo/restaurant/dto/RestaurantSearchParameter.java
@@ -9,5 +9,6 @@ public class RestaurantSearchParameter {
     private LocalDate date;
     private LocalTime time;
     private Integer partySize;
+    private Boolean preorderAvailable;
     // TODO: 향후 태그 검색 기능 추가 시, 여기에 필드 추가
 }

--- a/src/main/resources/mapper/RestaurantSearchMapper.xml
+++ b/src/main/resources/mapper/RestaurantSearchMapper.xml
@@ -45,6 +45,9 @@
                     s.max_capacity >= (IFNULL(res.total_party_size, 0) + #{partySize})
                 )
             </if>
+            <if test="preorderAvailable == true">
+                AND r.preorder_available = true
+            </if>
             <!--
                 TODO: 태그 검색 기능 확장
             -->


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- HomeView.vue 파일의 검색 필터에 선주문/선결제 허용 식당 검색 옵션 추가
- RestaurantSearchMapper.xml 파일의 식당 검색 쿼리에 선주문/선결제 허용 식당 검색 관련 <if> 태그 추가

## 📁 변경된 파일

- frontend/src/views/HomeView.vue
- src/main/java/com/example/LunchGo/restaurant/dto/RestaurantSearchParameter.java
- src/main/resources/mapper/RestaurantSearchMapper.xml

## 🔗 관련 Issue(선택)

- [[FEATURE] 선주문/선결제 가능 식당 검색 필터 추가 #398](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/398) 

## ✔️ 체크리스트(선택)

- 선주문/선결제 허용 식당 검색 기능 동작 확인
  - postman 테스트: 세번째 캡처의 sql문 실행 결과와 동일하게 실행됨을 확인

<details>
  <summary>실행 결과 캡처</summary>

   <img width="1703" height="1499" alt="image" src="https://github.com/user-attachments/assets/ca978be1-470d-4b74-8f30-0a84fba36f2f" />

<img width="1703" height="1501" alt="image" src="https://github.com/user-attachments/assets/6d3d71b6-6e95-4af5-95da-a71558e3dd88" />

<img width="2177" height="1239" alt="image" src="https://github.com/user-attachments/assets/8cef0c90-9df3-438e-9ed4-88900d130b68" />

</details>