### PR TITLE
feat: 예약 내역 정렬 우선순위/최신순 적용

### DIFF
--- a/src/main/java/com/example/LunchGo/reservation/dto/ReservationHistoryItem.java
+++ b/src/main/java/com/example/LunchGo/reservation/dto/ReservationHistoryItem.java
@@ -1,6 +1,7 @@
 package com.example.LunchGo.reservation.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -21,6 +22,7 @@ public class ReservationHistoryItem {
     private PaymentInfo payment;
     private String reservationStatus;
     private String cancelledBy;
+    private LocalDateTime cancelledAt;
     private ReviewInfo review;
 
     @Getter

--- a/src/main/java/com/example/LunchGo/reservation/mapper/row/ReservationHistoryRow.java
+++ b/src/main/java/com/example/LunchGo/reservation/mapper/row/ReservationHistoryRow.java
@@ -1,6 +1,7 @@
 package com.example.LunchGo.reservation.mapper.row;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.Getter;
 import lombok.Setter;
@@ -29,6 +30,7 @@ public class ReservationHistoryRow {
     private Integer totalAmount;
 
     private String cancelledBy;
+    private LocalDateTime cancelledAt;
 
     private Long reviewId;
     private Integer reviewRating;

--- a/src/main/java/com/example/LunchGo/reservation/service/ReservationHistoryServiceImpl.java
+++ b/src/main/java/com/example/LunchGo/reservation/service/ReservationHistoryServiceImpl.java
@@ -87,6 +87,7 @@ public class ReservationHistoryServiceImpl implements ReservationHistoryService 
                 payment,
                 row.getReservationStatus(),
                 row.getCancelledBy(),
+                row.getCancelledAt(),
                 review
             ));
         }

--- a/src/main/resources/mapper/ReservationHistoryMapper.xml
+++ b/src/main/resources/mapper/ReservationHistoryMapper.xml
@@ -16,6 +16,7 @@
             r.party_size AS partySize,
             r.status AS reservationStatus,
             cxl.cancelled_by AS cancelledBy,
+            cxl.cancelled_at AS cancelledAt,
             CASE
                 WHEN r.status = 'COMPLETED' THEN rvs.visit_number
                 ELSE NULL
@@ -74,6 +75,7 @@
             r.party_size,
             r.status,
             cxl.cancelled_by,
+            cxl.cancelled_at,
             rvs.visit_number,
             rvs.days_since_last_visit,
             rc.confirmed_amount,


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 예약 내역/지난 예약 모두 상태 우선순위(예약확정 → 결제대기 → 취소)로 정렬하고, 동일 상태 내에서는 최근 작업이 위로 오도록 정렬 기준을 통일. 
- 취소 건은 취소시각을 기준으로 정렬되도록 백엔드 응답에 취소 시각을 추가.

## 📁 변경된 파일

- frontend/src/views/my-reservations/MyReservationsPage.vue
- src/main/java/com/example/LunchGo/reservation/mapper/row/ReservationHistoryRow.java
- src/main/java/com/example/LunchGo/reservation/dto/ReservationHistoryItem.java
- src/main/java/com/example/LunchGo/reservation/service/ReservationHistoryServiceImpl.java
- src/main/resources/mapper/ReservationHistoryMapper.xml



