### PR TITLE
feat: 홈 지도 마커 그룹/즐겨찾기 리스트 표시

### DIFF
--- a/frontend/src/composables/useHomeMap.js
+++ b/frontend/src/composables/useHomeMap.js
@@ -9,6 +9,7 @@ export const useHomeMap = ({
   selectedDistanceKm,
   resolveRestaurantCoords,
   onMarkerClick,
+  favoriteIdSet,
   restaurants,
 }) => {
   const mapContainer = ref(null);
@@ -85,19 +86,32 @@ export const useHomeMap = ({
     mapMarkers.forEach((marker) => marker.setMap(null));
     mapMarkers.length = 0;
 
-    const markerSvg =
-      "data:image/svg+xml;utf8," +
-      "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='46' viewBox='0 0 32 46'>" +
-      "<path d='M16 1C8.8 1 3 6.8 3 14c0 9.3 13 30 13 30s13-20.7 13-30C29 6.8 23.2 1 16 1z' fill='%23ff6b4a' stroke='white' stroke-width='2'/>" +
-      "<circle cx='16' cy='14' r='5' fill='white'/>" +
-      "</svg>";
+    const buildMarkerSvg = (body) =>
+      `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(
+        `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46" viewBox="0 0 32 46">${body}</svg>`
+      )}`;
+    const markerSvg = buildMarkerSvg(
+      '<path d="M16 1C8.8 1 3 6.8 3 14c0 9.3 13 30 13 30s13-20.7 13-30C29 6.8 23.2 1 16 1z" fill="#ff6b4a" stroke="white" stroke-width="2"/>' +
+        '<circle cx="16" cy="14" r="5" fill="white"/>'
+    );
+    const favoriteMarkerSvg = buildMarkerSvg(
+      '<path d="M16 1C8.8 1 3 6.8 3 14c0 9.3 13 30 13 30s13-20.7 13-30C29 6.8 23.2 1 16 1z" fill="#007bff" stroke="white" stroke-width="2"/>' +
+        '<path d="M16 8.5l2.1 4.3 4.7.7-3.4 3.3.8 4.7-4.2-2.2-4.2 2.2.8-4.7-3.4-3.3 4.7-.7z" fill="white"/>'
+    );
     const markerImage = new kakaoMaps.MarkerImage(
       markerSvg,
       new kakaoMaps.Size(32, 46),
       { offset: new kakaoMaps.Point(16, 46) }
     );
+    const favoriteMarkerImage = new kakaoMaps.MarkerImage(
+      favoriteMarkerSvg,
+      new kakaoMaps.Size(32, 46),
+      { offset: new kakaoMaps.Point(16, 46) }
+    );
 
     const distanceLimit = selectedDistanceKm.value;
+    const favoriteIds = favoriteIdSet?.value ?? new Set();
+    const markerGroups = new Map();
 
     for (const restaurant of getRestaurants()) {
       const coords = await resolveRestaurantCoords(restaurant);
@@ -105,21 +119,33 @@ export const useHomeMap = ({
       if (distanceLimit && !isWithinDistance(coords, distanceLimit)) {
         continue;
       }
+      const coordKey = `${coords.lat.toFixed(6)},${coords.lng.toFixed(6)}`;
+      const group = markerGroups.get(coordKey) ?? {
+        coords,
+        restaurants: [],
+      };
+      group.restaurants.push(restaurant);
+      markerGroups.set(coordKey, group);
+    }
 
+    for (const group of markerGroups.values()) {
+      const hasFavorite = group.restaurants.some((item) =>
+        favoriteIds.has(Number(item.id))
+      );
       const marker = new kakaoMaps.Marker({
-        position: new kakaoMaps.LatLng(coords.lat, coords.lng),
-        title: restaurant.name,
-        image: markerImage,
+        position: new kakaoMaps.LatLng(group.coords.lat, group.coords.lng),
+        title: group.restaurants[0]?.name ?? "",
+        image: hasFavorite ? favoriteMarkerImage : markerImage,
       });
 
       try {
         marker.setMap(mapInstance.value);
         kakaoMaps.event.addListener(marker, "click", () => {
-          onMarkerClick?.(restaurant);
+          onMarkerClick?.(group.restaurants);
         });
         mapMarkers.push(marker);
       } catch (error) {
-        console.error("지도 마커 표시 실패:", restaurant?.name, error);
+        console.error("지도 마커 표시 실패:", group?.restaurants?.[0]?.name, error);
       }
     }
   };
@@ -305,6 +331,13 @@ export const useHomeMap = ({
 
     scheduleMapMarkerRender();
   });
+
+  watch(
+    () => favoriteIdSet?.value,
+    () => {
+      scheduleMapMarkerRender();
+    }
+  );
 
   onBeforeUnmount(() => {
     mapMarkers.forEach((marker) => marker.setMap(null));

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -237,9 +237,12 @@ const selectedDistanceKm = computed(() => {
 
 const restaurantGeocodeCache = new Map();
 
-const handleMapMarkerClick = (restaurant) => {
-  updateSelectedMapRestaurant(restaurant);
-  ensureReviewSummary(restaurant);
+const handleMapMarkerClick = (restaurants = []) => {
+  if (!restaurants.length) return;
+  updateSelectedMapRestaurants(restaurants);
+  restaurants.forEach((restaurant) => {
+    ensureReviewSummary(restaurant);
+  });
 };
 
 async function resolveRestaurantCoords(restaurant) {
@@ -308,6 +311,7 @@ const {
   selectedDistanceKm,
   resolveRestaurantCoords,
   onMarkerClick: handleMapMarkerClick,
+  favoriteIdSet,
   restaurants: restaurantData,
 });
 


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 같은 좌표 식당을 하나의 마커로 묶고 클릭 시 리스트로 표시. 즐겨찾기 포함 그룹은 파란 마커로 표시하고 리스트에 즐겨찾기 배지 추가. 
- SVG 마커 인코딩 처리 및 즐겨찾기 변경 시 마커 재렌더 반영.

## 📁 변경된 파일

- frontend/src/composables/useHomeMap.js
- frontend/src/views/HomeView.vue

