### PR TITLE
feat: 홈 지도 공유 즐겨찾기 마커 표시 개선

### DIFF
--- a/frontend/src/components/ui/MapMarkerLegendIcon.vue
+++ b/frontend/src/components/ui/MapMarkerLegendIcon.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { MARKER_BASE_PATH, MARKER_STAR_PATH } from "@/utils/mapMarkerSvgs";
+
+const props = defineProps({
+  fill: {
+    type: String,
+    default: "#007bff",
+  },
+  starFill: {
+    type: String,
+    default: "white",
+  },
+});
+</script>
+
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="20"
+    viewBox="0 0 32 46"
+    aria-hidden="true"
+  >
+    <path
+      :d="MARKER_BASE_PATH"
+      :fill="props.fill"
+      stroke="white"
+      stroke-width="2"
+    />
+    <path :d="MARKER_STAR_PATH" :fill="props.starFill" />
+  </svg>
+</template>

--- a/frontend/src/utils/mapMarkerSvgs.js
+++ b/frontend/src/utils/mapMarkerSvgs.js
@@ -1,0 +1,21 @@
+export const MARKER_BASE_PATH =
+  "M16 1C8.8 1 3 6.8 3 14c0 9.3 13 30 13 30s13-20.7 13-30C29 6.8 23.2 1 16 1z";
+export const MARKER_STAR_PATH =
+  "M16 8.5l2.1 4.3 4.7.7-3.4 3.3.8 4.7-4.2-2.2-4.2 2.2.8-4.7-3.4-3.3 4.7-.7z";
+
+export const buildMarkerBody = (fill, accentMarkup) =>
+  `<path d="${MARKER_BASE_PATH}" fill="${fill}" stroke="white" stroke-width="2"/>${accentMarkup}`;
+
+export const buildMarkerCircle = (fill = "white") =>
+  `<circle cx="16" cy="14" r="5" fill="${fill}"/>`;
+
+export const buildMarkerStar = (fill = "white") =>
+  `<path d="${MARKER_STAR_PATH}" fill="${fill}"/>`;
+
+export const buildMarkerDataUri = (
+  body,
+  { width = 32, height = 46, viewBox = "0 0 32 46" } = {}
+) =>
+  `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="${viewBox}">${body}</svg>`
+  )}`;

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -29,6 +29,7 @@ import HomeSearchBar from "@/components/ui/HomeSearchBar.vue";
 import HomeRecommendationContent from "@/components/ui/HomeRecommendationContent.vue";
 import HomeRecommendationHeader from "@/components/ui/HomeRecommendationHeader.vue";
 import HomePagination from "@/components/ui/HomePagination.vue";
+import MapMarkerLegendIcon from "@/components/ui/MapMarkerLegendIcon.vue";
 import { useCafeteriaRecommendation } from "@/composables/useCafeteriaRecommendation";
 import { useTrendingRestaurants } from "@/composables/useTrendingRestaurants";
 import { useBudgetRecommendation, extractPriceValue } from "@/composables/useBudgetRecommendation";
@@ -1803,47 +1804,13 @@ onBeforeUnmount(() => {
             <span
                 class="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-white"
             >
-              <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="16"
-                  height="20"
-                  viewBox="0 0 32 46"
-                  aria-hidden="true"
-              >
-                <path
-                    d="M16 1C8.8 1 3 6.8 3 14c0 9.3 13 30 13 30s13-20.7 13-30C29 6.8 23.2 1 16 1z"
-                    fill="#007bff"
-                    stroke="white"
-                    stroke-width="2"
-                />
-                <path
-                    d="M16 8.5l2.1 4.3 4.7.7-3.4 3.3.8 4.7-4.2-2.2-4.2 2.2.8-4.7-3.4-3.3 4.7-.7z"
-                    fill="white"
-                />
-              </svg>
+              <MapMarkerLegendIcon fill="#007bff" star-fill="white" />
               나의 즐겨찾기
             </span>
             <span
                 class="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-white"
             >
-              <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="16"
-                  height="20"
-                  viewBox="0 0 32 46"
-                  aria-hidden="true"
-              >
-                <path
-                    d="M16 1C8.8 1 3 6.8 3 14c0 9.3 13 30 13 30s13-20.7 13-30C29 6.8 23.2 1 16 1z"
-                    fill="#ffc107"
-                    stroke="white"
-                    stroke-width="2"
-                />
-                <path
-                    d="M16 8.5l2.1 4.3 4.7.7-3.4 3.3.8 4.7-4.2-2.2-4.2 2.2.8-4.7-3.4-3.3 4.7-.7z"
-                    fill="white"
-                />
-              </svg>
+              <MapMarkerLegendIcon fill="#ffc107" star-fill="white" />
               공유 즐겨찾기
             </span>
           </div>


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->
- 공유 즐겨찾기 마커/라벨/배지 표시 추가

- 지도 마커 그룹 라벨 및 모달 카드 표시 조정

- 로그인 상태에서만 마커 legend 노출

<img width="426" height="458" alt="스크린샷 2026-01-14 오전 11 53 13" src="https://github.com/user-attachments/assets/41ef0b88-fb01-4274-8305-0c5abbc25ad5" />


## 📁 변경된 파일

- frontend/src/composables/useHomeMap.js

- frontend/src/views/HomeView.vue

## 공유사항 to 리뷰어 <!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요.-->

## 🔗 관련 Issue(선택)

- closes #485 

## ✔️ 체크리스트(선택)

- ex) 테스트 통과 확인
