### PR TITLE
feat: 추천순/평점순 정렬 안정화 및 추천순 적용 보완

### DIFF
--- a/frontend/src/composables/useHomeRecommendations.js
+++ b/frontend/src/composables/useHomeRecommendations.js
@@ -29,11 +29,7 @@ export const useHomeRecommendations = ({
   RECOMMEND_TRENDING,
 }) => {
   const applyFilters = () => {
-    const nextSort =
-      filterForm.sort === "추천순"
-        ? selectedSort.value
-        : filterForm.sort || sortOptions[0];
-    selectedSort.value = nextSort;
+    selectedSort.value = filterForm.sort || sortOptions[0];
     selectedPriceRange.value = filterForm.priceRange || null;
     selectedRecommendation.value = filterForm.recommendation || null;
     if (selectedRecommendation.value === RECOMMEND_BUDGET) {


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 추천순 선택 시 정렬값이 바로 적용되도록 필터 적용 로직 수정
- 추천순 정렬을 스냅샷 기반 점수 계산으로 고정해 복귀/새로고침 시 리스트 흔들림 방지
- 평점/추천 공통 스코어 정렬 로딩 처리 범위 확장

## 📁 변경된 파일

- frontend/src/composables/useHomeRecommendations.js
- frontend/src/views/HomeView.vue

