### PR TITLE
feat(holiday): 식당 정기휴무일 여부에 따른 영업 상태 갱신용 스케줄러 추가 

### DIFF
--- a/src/main/java/com/example/LunchGo/restaurant/mapper/RestaurantStatusMapper.java
+++ b/src/main/java/com/example/LunchGo/restaurant/mapper/RestaurantStatusMapper.java
@@ -14,14 +14,13 @@ public interface RestaurantStatusMapper {
      * @param status    변경할 식당 상태
      * @return 영향을 받은 행의 수
      */
-    int updateHolidayRestaurants(@Param("dayOfWeek") int dayOfWeek, @Param("status") RestaurantStatus status);
+    int updateHolidayRestaurants(@Param("dayOfWeek") int dayOfWeek);
 
     /**
      * 특정 요일에 정기 휴무일이 아닌 식당의 상태를 대량으로 업데이트합니다.
      *
      * @param dayOfWeek MySQL DAYOFWEEK() 기준 요일
-     * @param status    변경할 식당 상태
      * @return 영향을 받은 행의 수
      */
-    int updateNonHolidayRestaurants(@Param("dayOfWeek") int dayOfWeek, @Param("status") RestaurantStatus status);
+    int updateNonHolidayRestaurants(@Param("dayOfWeek") int dayOfWeek);
 }

--- a/src/main/java/com/example/LunchGo/restaurant/mapper/RestaurantStatusMapper.java
+++ b/src/main/java/com/example/LunchGo/restaurant/mapper/RestaurantStatusMapper.java
@@ -1,6 +1,5 @@
 package com.example.LunchGo.restaurant.mapper;
 
-import com.example.LunchGo.restaurant.domain.RestaurantStatus;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -11,7 +10,6 @@ public interface RestaurantStatusMapper {
      * 특정 요일에 정기 휴무일인 식당의 상태를 대량으로 업데이트합니다.
      *
      * @param dayOfWeek MySQL DAYOFWEEK() 기준 요일 (1=일, 2=월, ..., 7=토)
-     * @param status    변경할 식당 상태
      * @return 영향을 받은 행의 수
      */
     int updateHolidayRestaurants(@Param("dayOfWeek") int dayOfWeek);

--- a/src/main/java/com/example/LunchGo/restaurant/mapper/RestaurantStatusMapper.java
+++ b/src/main/java/com/example/LunchGo/restaurant/mapper/RestaurantStatusMapper.java
@@ -1,0 +1,27 @@
+package com.example.LunchGo.restaurant.mapper;
+
+import com.example.LunchGo.restaurant.domain.RestaurantStatus;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface RestaurantStatusMapper {
+
+    /**
+     * 특정 요일에 정기 휴무일인 식당의 상태를 대량으로 업데이트합니다.
+     *
+     * @param dayOfWeek MySQL DAYOFWEEK() 기준 요일 (1=일, 2=월, ..., 7=토)
+     * @param status    변경할 식당 상태
+     * @return 영향을 받은 행의 수
+     */
+    int updateHolidayRestaurants(@Param("dayOfWeek") int dayOfWeek, @Param("status") RestaurantStatus status);
+
+    /**
+     * 특정 요일에 정기 휴무일이 아닌 식당의 상태를 대량으로 업데이트합니다.
+     *
+     * @param dayOfWeek MySQL DAYOFWEEK() 기준 요일
+     * @param status    변경할 식당 상태
+     * @return 영향을 받은 행의 수
+     */
+    int updateNonHolidayRestaurants(@Param("dayOfWeek") int dayOfWeek, @Param("status") RestaurantStatus status);
+}

--- a/src/main/java/com/example/LunchGo/restaurant/repository/RegularHolidayRepository.java
+++ b/src/main/java/com/example/LunchGo/restaurant/repository/RegularHolidayRepository.java
@@ -26,6 +26,4 @@ public interface RegularHolidayRepository extends JpaRepository<RegularHoliday, 
     @Query("DELETE FROM RegularHoliday rh WHERE rh.restaurantId = :restaurantId")
     void deleteAllByRestaurantId(@Param("restaurantId") Long restaurantId);
 
-    @Query("SELECT rh.restaurantId FROM RegularHoliday rh WHERE rh.dayOfWeek = :dayOfWeek")
-    List<Long> findRestaurantIdsByDayOfWeek(@Param("dayOfWeek") int dayOfWeek);
 }

--- a/src/main/java/com/example/LunchGo/restaurant/repository/RegularHolidayRepository.java
+++ b/src/main/java/com/example/LunchGo/restaurant/repository/RegularHolidayRepository.java
@@ -25,4 +25,7 @@ public interface RegularHolidayRepository extends JpaRepository<RegularHoliday, 
     @Modifying
     @Query("DELETE FROM RegularHoliday rh WHERE rh.restaurantId = :restaurantId")
     void deleteAllByRestaurantId(@Param("restaurantId") Long restaurantId);
+
+    @Query("SELECT rh.restaurantId FROM RegularHoliday rh WHERE rh.dayOfWeek = :dayOfWeek")
+    List<Long> findRestaurantIdsByDayOfWeek(@Param("dayOfWeek") int dayOfWeek);
 }

--- a/src/main/java/com/example/LunchGo/restaurant/service/RestaurantStatusScheduler.java
+++ b/src/main/java/com/example/LunchGo/restaurant/service/RestaurantStatusScheduler.java
@@ -2,6 +2,7 @@ package com.example.LunchGo.restaurant.service;
 
 import com.example.LunchGo.restaurant.domain.RestaurantStatus;
 import com.example.LunchGo.restaurant.mapper.RestaurantStatusMapper;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -24,12 +25,12 @@ public class RestaurantStatusScheduler {
      * - 나머지 영업 가능한 식당은 'OPEN'으로 변경합니다.
      * - 'DELETED' 상태의 식당은 변경 대상에서 제외합니다.
      */
-    @Scheduled(cron = "0 0 6 * * *")
+    @Scheduled(cron = "0 0 6 * * *", zone = "Asia/Seoul")
     @Transactional
     public void updateRestaurantStatus() {
         log.info("매일 오전 6시 식당 영업상태 업데이트 스케줄러 시작 (MyBatis)");
 
-        DayOfWeek today = LocalDate.now().getDayOfWeek();
+        DayOfWeek today = LocalDate.now(ZoneId.of("Asia/Seoul")).getDayOfWeek();
         // MySQL DAYOFWEEK() 함수 기준 (일요일=1, 월요일=2 ... 토요일=7)으로 변환
         int todayValue = today.getValue() % 7 + 1;
 

--- a/src/main/java/com/example/LunchGo/restaurant/service/RestaurantStatusScheduler.java
+++ b/src/main/java/com/example/LunchGo/restaurant/service/RestaurantStatusScheduler.java
@@ -33,9 +33,13 @@ public class RestaurantStatusScheduler {
         // MySQL DAYOFWEEK() 함수 기준 (일요일=1, 월요일=2 ... 토요일=7)으로 변환
         int todayValue = today.getValue() % 7 + 1;
 
-        int closedCount = restaurantStatusMapper.updateHolidayRestaurants(todayValue, RestaurantStatus.CLOSED);
-        int openCount = restaurantStatusMapper.updateNonHolidayRestaurants(todayValue, RestaurantStatus.OPEN);
+        int closedCount = restaurantStatusMapper.updateHolidayRestaurants(todayValue);
+        int openCount = restaurantStatusMapper.updateNonHolidayRestaurants(todayValue);
 
-        log.info("식당 영업상태 업데이트 완료. OPEN으로 변경: {}곳, CLOSED로 변경: {}곳", openCount, closedCount);
+        if (closedCount > 0 || openCount > 0) {
+            log.info("식당 영업상태 업데이트 완료. OPEN으로 변경: {}곳, CLOSED로 변경: {}곳", openCount, closedCount);
+        } else {
+            log.info("식당 영업상태 변경 사항 없음.");
+        }
     }
 }

--- a/src/main/java/com/example/LunchGo/restaurant/service/RestaurantStatusScheduler.java
+++ b/src/main/java/com/example/LunchGo/restaurant/service/RestaurantStatusScheduler.java
@@ -1,0 +1,41 @@
+package com.example.LunchGo.restaurant.service;
+
+import com.example.LunchGo.restaurant.domain.RestaurantStatus;
+import com.example.LunchGo.restaurant.mapper.RestaurantStatusMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RestaurantStatusScheduler {
+
+    private final RestaurantStatusMapper restaurantStatusMapper;
+
+    /**
+     * 매일 오전 6시에 식당의 영업 상태를 업데이트합니다.
+     * - 정기 휴무일인 식당은 'CLOSED'로 변경합니다.
+     * - 나머지 영업 가능한 식당은 'OPEN'으로 변경합니다.
+     * - 'DELETED' 상태의 식당은 변경 대상에서 제외합니다.
+     */
+    @Scheduled(cron = "0 0 6 * * *")
+    @Transactional
+    public void updateRestaurantStatus() {
+        log.info("매일 오전 6시 식당 영업상태 업데이트 스케줄러 시작 (MyBatis)");
+
+        DayOfWeek today = LocalDate.now().getDayOfWeek();
+        // MySQL DAYOFWEEK() 함수 기준 (일요일=1, 월요일=2 ... 토요일=7)으로 변환
+        int todayValue = today.getValue() % 7 + 1;
+
+        int closedCount = restaurantStatusMapper.updateHolidayRestaurants(todayValue, RestaurantStatus.CLOSED);
+        int openCount = restaurantStatusMapper.updateNonHolidayRestaurants(todayValue, RestaurantStatus.OPEN);
+
+        log.info("식당 영업상태 업데이트 완료. OPEN으로 변경: {}곳, CLOSED로 변경: {}곳", openCount, closedCount);
+    }
+}

--- a/src/main/resources/mapper/RestaurantStatusMapper.xml
+++ b/src/main/resources/mapper/RestaurantStatusMapper.xml
@@ -4,7 +4,7 @@
 
     <update id="updateHolidayRestaurants" parameterType="map">
         UPDATE restaurants r
-        SET r.status = #{status}
+        SET r.status = 'CLOSED'
         WHERE EXISTS (
             SELECT 1
             FROM regular_holidays rh
@@ -16,7 +16,7 @@
 
     <update id="updateNonHolidayRestaurants" parameterType="map">
         UPDATE restaurants r
-        SET r.status = #{status}
+        SET r.status = 'OPEN'
         WHERE NOT EXISTS (
             SELECT 1
             FROM regular_holidays rh

--- a/src/main/resources/mapper/RestaurantStatusMapper.xml
+++ b/src/main/resources/mapper/RestaurantStatusMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.LunchGo.restaurant.mapper.RestaurantStatusMapper">
+
+    <update id="updateHolidayRestaurants" parameterType="map">
+        UPDATE restaurants r
+        SET r.status = #{status}
+        WHERE EXISTS (
+            SELECT 1
+            FROM regular_holidays rh
+            WHERE rh.restaurant_id = r.restaurant_id
+              AND rh.day_of_week = #{dayOfWeek}
+        )
+        AND r.status != 'DELETED'
+    </update>
+
+    <update id="updateNonHolidayRestaurants" parameterType="map">
+        UPDATE restaurants r
+        SET r.status = #{status}
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM regular_holidays rh
+            WHERE rh.restaurant_id = r.restaurant_id
+              AND rh.day_of_week = #{dayOfWeek}
+        )
+        AND r.status != 'DELETED'
+    </update>
+
+</mapper>


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 매일 오전 6시마다 요일을 확인하여 폐업(DELETED)하지 않은 식당 중 현재 날짜상 정기휴무일에 해당하는 식당의 영업상태를 'CLOSED'로, 그 외의 모든 식당들의 영업상태를 'OPEN'으로 변경하는 스케줄러 추가

## 📁 변경된 파일

- src/main/java/com/example/LunchGo/restaurant/mapper/RestaurantStatusMapper.java
- src/main/java/com/example/LunchGo/restaurant/repository/RegularHolidayRepository.java
- src/main/java/com/example/LunchGo/restaurant/service/RestaurantStatusScheduler.java
- src/main/resources/mapper/RestaurantStatusMapper.xml

## 🔗 관련 Issue(선택)

- [[FEATURE] 정기휴무일 스케줄러 추가 #512](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/512)