### PR TITLE
fix(concurrency): redisson 커넥션 풀 개수 조정

### DIFF
--- a/src/main/java/com/example/LunchGo/common/config/RedissonConfig.java
+++ b/src/main/java/com/example/LunchGo/common/config/RedissonConfig.java
@@ -20,10 +20,10 @@ public class RedissonConfig {
 
     private static final String REDIS_PROTOCOL_FORMAT = "redis://%s:%d";
 
-    @Value("${spring.redis.redisson.pool.size:64}")
+    @Value("${spring.redis.redisson.pool.size}")
     private int connectionPoolSize;
 
-    @Value("${spring.redis.redisson.pool.min-idle-size:24}")
+    @Value("${spring.redis.redisson.pool.min-idle-size}")
     private int connectionMinIdleSize;
 
     private final RedisProperties redisProperties;

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -11,6 +11,10 @@ spring.data.redis.host=10.0.2.6
 spring.data.redis.port=6379
 spring.data.redis.password=${REDIS_PASSWORD}
 
+# Redisson Connection Pool
+spring.redis.redisson.pool.size=64
+spring.redis.redisson.pool.min-idle-size=24
+
 # Object Storage
 ncp.object-storage.endpoint=https://kr.object.ncloudstorage.com
 ncp.object-storage.region=kr-standard


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- Redisson의 커넥션 풀 개수 최소치, 최대치를 각각 기본값인 24, 64로 상향
 
## 📁 변경된 파일

- src/main/java/com/example/LunchGo/common/config/RedissonConfig.java

## 공유사항 to 리뷰어 <!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요.-->

- 로컬에서의 변경 내역은 원격 서버에 반영되지 않아 부하테스트를 진행하기 전 변경사항을 먼저 적용합니다.  


## 🔗 관련 Issue(선택)

- [[FEATURE] 예약 기능 개선 - Redis 커넥션 풀 개수 설정 수정 #516](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/516)
