### PR TITLE
fix(concurrency): lettuce 커넥션 풀 개수 조정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
 	// Redis 의존성 추가(lettuce)
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.apache.commons:commons-pool2'
 	implementation 'org.redisson:redisson-spring-boot-starter:3.43.0'
 
 	//이메일 의존성 추가

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -11,6 +11,12 @@ spring.data.redis.host=10.0.2.6
 spring.data.redis.port=6379
 spring.data.redis.password=${REDIS_PASSWORD}
 
+# Lettuce Connection Pool
+spring.data.redis.lettuce.pool.max-active=64
+spring.data.redis.lettuce.pool.max-idle=32
+spring.data.redis.lettuce.pool.min-idle=24
+spring.data.redis.lettuce.pool.max-wait=3000ms
+
 # Redisson Connection Pool
 spring.redis.redisson.pool.size=64
 spring.redis.redisson.pool.min-idle-size=24


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- lettuce 커넥션 풀 개수의 최소값, 최대값을 redisson과 동일하게 24, 64개로 조정

## 📁 변경된 파일

- build.gradle
- src/main/java/com/example/LunchGo/common/config/RedisConfig.java
- src/main/resources/application-prod.properties

## 공유사항 to 리뷰어 <!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요.-->

- 예약 기능 개선 관련 리팩토링 작업에는 다소 시간이 걸릴 것 같아 일단 변경한 커넥션 풀 개수만 반영해서 부하테스트를 진행해본 다음 바로 이어서 진행하겠습니다.

## 🔗 관련 Issue(선택)

- [[FEATURE] 예약 기능 개선 - 예약 생성 관련 로직 개선 + Redis 커넥션 풀 개수 조정 #521](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/521)

## ✔️ 체크리스트(선택)

- 커넥션 풀 설정 변경 이후에도 애플리케이션이 정상 실행됨을 확인
