### PR TITLE
refactor(reservation): 예약 생성 로직 개선

### DIFF
--- a/scripts/k6_reservation_loadtest_idempotence.js
+++ b/scripts/k6_reservation_loadtest_idempotence.js
@@ -1,0 +1,99 @@
+import http from "k6/http";
+import { check } from "k6";
+
+const baseUrl = __ENV.BASE_URL || "http://10.0.2.6:8080";
+const emailPrefix = __ENV.EMAIL_PREFIX || "loadtest.user";
+const emailDomain = __ENV.EMAIL_DOMAIN || "example.com";
+const password = __ENV.PASSWORD || "Passw0rd!123";
+
+const restaurantId = Number(__ENV.RESTAURANT_ID || 4);
+const slotDate = __ENV.SLOT_DATE || "2026-01-16";
+const slotTime = __ENV.SLOT_TIME || "12:00";
+const partySize = Number(__ENV.PARTY_SIZE || 4);
+const reservationType = __ENV.RESERVATION_TYPE || "RESERVATION_DEPOSIT";
+
+const loadVus = Number(__ENV.LOAD_VUS || 10);
+const loadDuration = __ENV.LOAD_DURATION || "30s";
+
+export const options = {
+  scenarios: {
+    reservations: {
+      executor: "per-vu-iterations",
+      vus: loadVus,
+      iterations: 3, // 각 사용자가 3번씩 요청
+      maxDuration: loadDuration,
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+  },
+  setupTimeout: '10m',
+};
+
+function buildEmail(vu) {
+  const seq = String(vu).padStart(4, "0");
+  return `${emailPrefix}${seq}@${emailDomain}`;
+}
+
+export function setup() {
+  const users = [];
+  for (let i = 1; i <= loadVus; i++) {
+    const loginPayload = JSON.stringify({
+      email: buildEmail(i),
+      password,
+      userType: "USER",
+    });
+
+    const loginRes = http.post(`${baseUrl}/api/login`, loginPayload, {
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (loginRes.status === 200) {
+      const loginBody = loginRes.json();
+      users.push({
+        token: loginBody.accessToken,
+        userId: loginBody.id,
+      });
+    } else {
+      console.error(`Login failed for user ${i}: ${loginRes.status} ${loginRes.body}`);
+    }
+  }
+  return users;
+}
+
+export default function (users) {
+  const vu = __VU;
+  const iter = __ITER;
+  const user = users[vu - 1];
+
+  if (!user) {
+    console.error(`VU ${vu} has no user data.`);
+    return;
+  }
+
+  const { token, userId } = user;
+
+  const reservePayload = JSON.stringify({
+    userId,
+    restaurantId,
+    slotDate,
+    slotTime,
+    partySize,
+    reservationType,
+    requestMessage: null,
+  });
+
+  const reserveRes = http.post(`${baseUrl}/api/reservations`, reservePayload, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  check(reserveRes, {
+    // 첫 번째 요청은 성공(2xx)해야 하지만, 다른 유저와의 경합으로 실패(4xx)할 수 있음
+    "first request is 2xx or 4xx": (r) => iter === 0 ? (r.status >= 200 && r.status < 500) : true,
+    // 두 번째 이후의 요청은 반드시 중복으로 인해 실패(4xx)해야 함
+    "subsequent requests are blocked (4xx)": (r) => iter > 0 ? (r.status >= 400 && r.status < 500) : true,
+  });
+}

--- a/scripts/k6_reservation_loadtest_reservation.js
+++ b/scripts/k6_reservation_loadtest_reservation.js
@@ -1,0 +1,95 @@
+import http from "k6/http";
+import { check } from "k6";
+
+const baseUrl = __ENV.BASE_URL || "http://10.0.2.6:8080";
+const emailPrefix = __ENV.EMAIL_PREFIX || "loadtest.user";
+const emailDomain = __ENV.EMAIL_DOMAIN || "example.com";
+const password = __ENV.PASSWORD || "Passw0rd!123";
+
+const restaurantId = Number(__ENV.RESTAURANT_ID || 4);
+const slotDate = __ENV.SLOT_DATE || "2026-01-16";
+const slotTime = __ENV.SLOT_TIME || "12:00";
+const partySize = Number(__ENV.PARTY_SIZE || 4);
+const reservationType = __ENV.RESERVATION_TYPE || "RESERVATION_DEPOSIT";
+
+const loadVus = Number(__ENV.LOAD_VUS || 10);
+const loadDuration = __ENV.LOAD_DURATION || "30s";
+
+export const options = {
+  scenarios: {
+    reservations: {
+      executor: "per-vu-iterations",
+      vus: loadVus,
+      iterations: 1,
+      maxDuration: loadDuration,
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+  },
+  setupTimeout: '10m',
+};
+
+function buildEmail(vu) {
+  const seq = String(vu).padStart(4, "0");
+  return `${emailPrefix}${seq}@${emailDomain}`;
+}
+
+export function setup() {
+  const users = [];
+  for (let i = 1; i <= loadVus; i++) {
+    const loginPayload = JSON.stringify({
+      email: buildEmail(i),
+      password,
+      userType: "USER",
+    });
+
+    const loginRes = http.post(`${baseUrl}/api/login`, loginPayload, {
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (loginRes.status === 200) {
+      const loginBody = loginRes.json();
+      users.push({
+        token: loginBody.accessToken,
+        userId: loginBody.id,
+      });
+    } else {
+      console.error(`Login failed for user ${i}: ${loginRes.status} ${loginRes.body}`);
+    }
+  }
+  return users;
+}
+
+export default function (users) {
+  const vu = __VU;
+  const user = users[vu - 1];
+
+  if (!user) {
+    console.error(`VU ${vu} has no user data.`);
+    return;
+  }
+
+  const { token, userId } = user;
+
+  const reservePayload = JSON.stringify({
+    userId,
+    restaurantId,
+    slotDate,
+    slotTime,
+    partySize,
+    reservationType,
+    requestMessage: null,
+  });
+
+  const reserveRes = http.post(`${baseUrl}/api/reservations`, reservePayload, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  check(reserveRes, {
+    "reservation status 2xx/4xx": (r) => r.status >= 200 && r.status < 500,
+  });
+}

--- a/src/main/java/com/example/LunchGo/common/util/RedisUtil.java
+++ b/src/main/java/com/example/LunchGo/common/util/RedisUtil.java
@@ -93,17 +93,17 @@ public class RedisUtil {
     }
 
     /**
-     * 키의 값을 1 증가시키고 증가된 값을 반환합니다.
+     * 키의 값을 주어진 delta만큼 증가시키고 증가된 값을 반환합니다. (Redis INCRBY)
      */
-    public Long increment(String key) {
-        return template.opsForValue().increment(key);
+    public Long increment(String key, long delta) {
+        return template.opsForValue().increment(key, delta);
     }
 
     /**
-     * 키의 값을 1 감소시키고 감소된 값을 반환합니다.
+     * 키의 값을 주어진 delta만큼 감소시키고 감소된 값을 반환합니다. (Redis DECRBY)
      */
-    public Long decrement(String key) {
-        return template.opsForValue().decrement(key);
+    public Long decrement(String key, long delta) {
+        return template.opsForValue().increment(key, -delta);
     }
 
     /**

--- a/src/main/java/com/example/LunchGo/common/util/RedisUtil.java
+++ b/src/main/java/com/example/LunchGo/common/util/RedisUtil.java
@@ -10,6 +10,8 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
@@ -117,5 +119,16 @@ public class RedisUtil {
             log.error("Redis key [{}] has invalid numeric value: [{}]. Returning 0L.", key, val);
             return 0L;
         }
+    }
+
+    /**
+     * 예약 슬롯의 Redis 키를 생성합니다.
+     * @param restaurantId 식당 ID
+     * @param slotDate 예약 날짜
+     * @param slotTime 예약 시간
+     * @return 생성된 Redis 키 문자열 (예: "seats:1:2023-01-01:12:00")
+     */
+    public static String generateSeatKey(Long restaurantId, LocalDate slotDate, LocalTime slotTime) {
+        return "seats:" + restaurantId + ":" + slotDate.toString() + ":" + slotTime.toString();
     }
 }

--- a/src/main/java/com/example/LunchGo/reservation/aop/DistributedLockAop.java
+++ b/src/main/java/com/example/LunchGo/reservation/aop/DistributedLockAop.java
@@ -64,7 +64,7 @@ public class DistributedLockAop {
 
         try {
             // 대기열 진입: 카운트 증가
-            redisUtil.increment(waitingCountKey);
+            redisUtil.increment(waitingCountKey, 1L);
 
             boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
             
@@ -96,7 +96,7 @@ public class DistributedLockAop {
                 rLock.unlock();
             }
             // 작업 종료(성공/실패/포기) 후 대기열 이탈: 카운트 감소
-            redisUtil.decrement(waitingCountKey);
+            redisUtil.decrement(waitingCountKey, 1L);
             
             // 개인 락은 성공 시 해제하지 않음 (TTL 유지)
             // 단, 예외가 발생해서 여기까지 왔다면(catch 블록을 거치지 않은 런타임 예외 등) 해제해야 할 수도 있지만,

--- a/src/main/java/com/example/LunchGo/reservation/dto/MenuSnapshot.java
+++ b/src/main/java/com/example/LunchGo/reservation/dto/MenuSnapshot.java
@@ -1,16 +1,14 @@
 package com.example.LunchGo.reservation.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-@Data
-@NoArgsConstructor
+@Getter
 @AllArgsConstructor
 public class MenuSnapshot {
-    private Long menuId;
-    private String menuName;
-    private Integer unitPrice;
-    private Integer quantity;
-    private Integer lineAmount;
+    private final Long menuId;
+    private final String menuName;
+    private final Integer unitPrice;
+    private final Integer quantity;
+    private final Integer lineAmount;
 }

--- a/src/main/java/com/example/LunchGo/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/com/example/LunchGo/reservation/mapper/ReservationMapper.java
@@ -2,6 +2,7 @@ package com.example.LunchGo.reservation.mapper;
 
 import com.example.LunchGo.reservation.domain.Reservation;
 import com.example.LunchGo.reservation.domain.ReservationSlot;
+import com.example.LunchGo.reservation.dto.MenuSnapshot;
 import com.example.LunchGo.reservation.mapper.row.ReservationCreateRow;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -67,13 +68,9 @@ public interface ReservationMapper {
             @Param("slotDate") java.time.LocalDate slotDate
     );
 
-    int insertReservationMenuItem(
+    int insertReservationMenuItems(
             @Param("reservationId") Long reservationId,
-            @Param("menuId") Long menuId,
-            @Param("menuName") String menuName,
-            @Param("unitPrice") Integer unitPrice,
-            @Param("quantity") Integer quantity,
-            @Param("lineAmount") Integer lineAmount
+            @Param("items") List<MenuSnapshot> items
     );
     List<ReservationMenuItemRow> selectReservationMenuItems(@Param("reservationId") Long reservationId);
 

--- a/src/main/java/com/example/LunchGo/reservation/service/ReservationRefundService.java
+++ b/src/main/java/com/example/LunchGo/reservation/service/ReservationRefundService.java
@@ -1,5 +1,6 @@
 package com.example.LunchGo.reservation.service;
 
+import com.example.LunchGo.common.util.RedisUtil;
 import com.example.LunchGo.reservation.domain.ReservationStatus;
 import com.example.LunchGo.reservation.entity.Payment;
 import com.example.LunchGo.reservation.entity.Reservation;
@@ -13,6 +14,8 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +33,7 @@ public class ReservationRefundService {
     private final ReservationSlotRepository reservationSlotRepository;
     private final PaymentRepository paymentRepository;
     private final PortoneCancelService portoneCancelService;
+    private final RedisUtil redisUtil; // Redis 좌석 카운터 관리를 위해 추가
 
     //회원(사용자) 취소
     @Transactional
@@ -131,6 +135,21 @@ public class ReservationRefundService {
         reservation.setStatus(
                 refundedTotal > 0 ? ReservationStatus.REFUNDED : ReservationStatus.CANCELLED
         );
+
+        // --- Redis 좌석 카운터 업데이트 (트랜잭션 커밋 후) ---
+        // DB 트랜잭션이 성공적으로 커밋된 후에만 Redis 좌석 카운터를 증가시켜 일관성을 유지합니다.
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                // 예약 슬롯 정보 (restaurantId, slotDate, slotTime) 및 partySize를 가져와 Redis 키 생성
+                String redisSeatKey = "seats:" + slot.getRestaurantId() + ":" + slot.getSlotDate() + ":" + slot.getSlotTime();
+                int partySize = reservation.getPartySize() != null ? reservation.getPartySize() : 0;
+
+                // Redis 좌석 카운터에 partySize만큼 좌석 반환 (증가)
+                // 만약 Redis 키가 중간에 만료되었더라도, increment는 0에서부터 시작하여 값을 추가하므로 문제 없음
+                redisUtil.increment(redisSeatKey, partySize);
+            }
+        });
 
         return refundedTotal;
     }

--- a/src/main/java/com/example/LunchGo/reservation/service/ReservationRefundService.java
+++ b/src/main/java/com/example/LunchGo/reservation/service/ReservationRefundService.java
@@ -142,7 +142,7 @@ public class ReservationRefundService {
             @Override
             public void afterCommit() {
                 // 예약 슬롯 정보 (restaurantId, slotDate, slotTime) 및 partySize를 가져와 Redis 키 생성
-                String redisSeatKey = "seats:" + slot.getRestaurantId() + ":" + slot.getSlotDate() + ":" + slot.getSlotTime();
+                String redisSeatKey = RedisUtil.generateSeatKey(slot.getRestaurantId(), slot.getSlotDate(), slot.getSlotTime());
                 int partySize = reservation.getPartySize() != null ? reservation.getPartySize() : 0;
 
                 // Redis 좌석 카운터에 partySize만큼 좌석 반환 (증가)

--- a/src/main/java/com/example/LunchGo/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/example/LunchGo/reservation/service/ReservationServiceImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ReservationServiceImpl implements ReservationService {
 
     private static final DateTimeFormatter CODE_DATE = DateTimeFormatter.ofPattern("yyyyMMdd");

--- a/src/main/java/com/example/LunchGo/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/example/LunchGo/reservation/service/ReservationServiceImpl.java
@@ -95,16 +95,7 @@ public class ReservationServiceImpl implements ReservationService {
 
         // reservation_menu_items 저장 (예약 PK 생긴 다음에)
         if (ReservationType.PREORDER_PREPAY.equals(request.getReservationType()) && menuSnapshots != null && !menuSnapshots.isEmpty()) {
-            for (MenuSnapshot s : menuSnapshots) {
-                reservationMapper.insertReservationMenuItem(
-                        reservation.getReservationId(),
-                        s.getMenuId(),
-                        s.getMenuName(),
-                        s.getUnitPrice(),
-                        s.getQuantity(),
-                        s.getLineAmount()
-                );
-            }
+            reservationMapper.insertReservationMenuItems(reservation.getReservationId(), menuSnapshots);
         }
 
         String code = generateReservationCode(LocalDate.now(), reservation.getReservationId());

--- a/src/main/java/com/example/LunchGo/restaurant/repository/MenuRepository.java
+++ b/src/main/java/com/example/LunchGo/restaurant/repository/MenuRepository.java
@@ -17,6 +17,8 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     Optional<Menu> findByMenuIdAndRestaurantIdAndIsDeletedFalse(Long menuId, Long restaurantId);
 
+    List<Menu> findAllByMenuIdInAndRestaurantIdAndIsDeletedFalse(List<Long> menuIds, Long restaurantId);
+
     // 참고: `updateMenu` 메서드는 제거되었습니다. 이제 메뉴 업데이트는 `MenuService.updateMenusForRestaurant`에서
     // JPA의 변경 감지(dirty checking) 메커니즘을 통해 처리됩니다. `isDeleted = false` 조건 검사는
     // `findAllByRestaurantIdAndIsDeletedFalse`를 통한 초기 조회 시 암묵적으로 처리됩니다.

--- a/src/main/resources/mapper/ReservationMapper.xml
+++ b/src/main/resources/mapper/ReservationMapper.xml
@@ -245,11 +245,13 @@
         ORDER BY r.created_at DESC
     </select>
 
-    <insert id="insertReservationMenuItem">
+    <insert id="insertReservationMenuItems">
         INSERT INTO reservation_menu_items
             (reservation_id, menu_id, menu_name, unit_price, quantity, line_amount)
         VALUES
-            (#{reservationId}, #{menuId}, #{menuName}, #{unitPrice}, #{quantity}, #{lineAmount})
+        <foreach collection="items" item="item" separator=",">
+            (#{reservationId}, #{item.menuId}, #{item.menuName}, #{item.unitPrice}, #{item.quantity}, #{item.lineAmount})
+        </foreach>
     </insert>
 
     <select id="selectBusinessReservationListByDate"


### PR DESCRIPTION
## 📌 작업 내용 <!-- 작업 사항에 대한 설명을 적어주세요 -->

- 선주문/선결제 진행 관련 메뉴 조회 및 등록 쿼리 개선
- 예약 관련 잔여석 처리 로직에 Redis 적용

## 📁 변경된 파일

- src/main/java/com/example/LunchGo/common/util/RedisUtil.java
- src/main/java/com/example/LunchGo/reservation/aop/DistributedLockAop.java
- src/main/java/com/example/LunchGo/reservation/dto/MenuSnapshot.java
- src/main/java/com/example/LunchGo/reservation/mapper/ReservationMapper.java
- src/main/java/com/example/LunchGo/reservation/service/ReservationFacade.java
- src/main/java/com/example/LunchGo/reservation/service/ReservationRefundService.java
- src/main/java/com/example/LunchGo/reservation/service/ReservationServiceImpl.java
- src/main/java/com/example/LunchGo/restaurant/repository/MenuRepository.java
- src/main/resources/mapper/ReservationMapper.xml

## 공유사항 to 리뷰어 <!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요.-->

- 이미 생성된 적 있는 예약 슬롯에 대해서는 동시성 락을 걸기 전 미리 예약 가능 여부를 판정할 수 있도록 Redis에 특정 예약 슬롯의 잔여석 데이터를 저장하는 기능을 추가하고, 이를 활용하여 락을 걸고 예약 생성 트랜잭션에 진입하기 전, 미리 예약 가능 여부를 빠르게 판정할 수 있도록 개선했습니다.
- 예약 생성 시 Redis에 저장된 잔여석에서 예약한 인원을 차감하는 기능을 추가했기 때문에, 취소된 예약의 인원수만큼 Redis의 잔여석을 회복시키는 로직을 예약 취소/환불 기능의 마지막에 추가했습니다.
- 부하테스트는 PR 병합 후 진행 예정입니다.

## 🔗 관련 Issue(선택)

- [[FEATURE] 예약 기능 쿼리 개선 #527](https://github.com/SSG9-FINAL-LunchGO/LunchGO/issues/527)
